### PR TITLE
fix: import csv should ignore rows with checkpoints or conflicts; make names more descriptive

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/builder/CsvUtil.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/builder/CsvUtil.java
@@ -611,14 +611,15 @@ public class CsvUtil {
             }
           }
 
-          // TODO: should resolve this properly when we have conflict rows and
-          // uncommitted edits. For now, we just add our csv import to those,
-          // rather than resolve the problems.
+          // if there are any conflicts or checkpoints on this row, we do not import
+          // this row change. Instead, silently ignore them.
           UserTable table = supervisor.getDatabase()
               .privilegedGetRowsWithId(appName, db, tableId, orderedDefns, v_id);
           if (table.getNumberOfRows() > 1) {
-            throw new IllegalStateException(
-                "There are either checkpoint or conflict rows in the destination table");
+            WebLogger.getLogger(appName).w(TAG,
+                "importSeparable: tableId: " + tableId + " rowId: " + v_id +
+                    " has checkpoints or conflicts -- IGNORED in .csv");
+            continue;
           }
 
           SyncState syncState = null;

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/utilities/QueryUtil.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/utilities/QueryUtil.java
@@ -24,16 +24,12 @@ public final class QueryUtil {
    * All five are used in ODKDatabaseImplUtils
    */
   @SuppressWarnings("unused")
-  public static final String GET_ROWS_WITH_ID_WHERE = DataTableColumns.ID + "=?";
+  public static final String WHERE_CLAUSE_ROWS_WITH_ID_EQUALS = DataTableColumns.ID + "=?";
   @SuppressWarnings("unused")
-  public static final String[] GET_ROWS_WITH_ID_GROUP_BY = null;
-  @SuppressWarnings("unused")
-  public static final String GET_ROWS_WITH_ID_HAVING = null;
-  @SuppressWarnings("unused")
-  public static final String[] GET_ROWS_WITH_ID_ORDER_BY_KEYS = {
+  public static final String[] ORDER_BY_SAVEPOINT_TIMESTAMP = {
       DataTableColumns.SAVEPOINT_TIMESTAMP };
   @SuppressWarnings("unused")
-  public static final String[] GET_ROWS_WITH_ID_ORDER_BY_DIR = { "DESC" };
+  public static final String[] ORDER_BY_DESCENDING = { "DESC" };
 
   /**
    * This class should never be instantiated


### PR DESCRIPTION
This is a joint pull with: 
#https://github.com/opendatakit/services/pull/16
(the change in constants will break services until you apply that pull).

1. when the initialization logic runs to import csv files, the importer should ignore rows that have checkpoints or conflicts (since it can't import its content onto those rows) and, presumably, these rows were edited by the user and the user's changes should take precedence over the static initialization logic.  Left unchanged, if you have a table that has initialization content (e.g., geotagger) and if you edit a record with survey, then force-close Survey without finalizing or saving as incomplete (so you have a checkpoint row in the database), then if you open ODK Tables, it will cause a force close because of the thrown exception. The correct behavior is to complete the intialization then resolve the checkpoint.

2. The names for some constants where not descriptive of what they contained, but were descriptive of the context in which they were used, which was not useful.