### PR TITLE
fix for 4.2 and 4.3 start-up crashes

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/PRNGFixes.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/PRNGFixes.java
@@ -61,10 +61,17 @@ public final class PRNGFixes {
     }
 
     try {
+	  // because the seed is a byte[] 
+	  // and invoke's 2nd argument is Varargs
+	  // we need to supply it as an object
+	  // array of arguments, the first of which
+	  // is the byte[] array.
+	  Object[] args = new Object[1];
+	  args[0] = generateSeed();
       // Mix in the device- and invocation-specific seed.
       Class.forName("org.apache.harmony.xnet.provider.jsse.NativeCrypto")
           .getMethod("RAND_seed", byte[].class)
-          .invoke(null, generateSeed());
+          .invoke(null, args);
 
       // Mix output of Linux PRNG into OpenSSL's PRNG
       int bytesRead = (Integer) Class.forName(
@@ -266,6 +273,8 @@ public final class PRNGFixes {
         DataInputStream in;
         synchronized (urandomMutex) {
           in = getUrandomInputStream();
+        }
+        synchronized (in) {
           in.readFully(bytes);
         }
       } catch (IOException e) {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/PRNGFixes.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/PRNGFixes.java
@@ -204,8 +204,11 @@ public final class PRNGFixes {
   /**
    * {@link SecureRandomSpi} which passes all requests to the Linux PRNG
    * ({@code /dev/urandom}).
+   *
+   * NOTE: needs to be public so that it can be created via reflection from
+   * within the security provider layer.
    */
-  private static class LinuxPRNGSecureRandom extends SecureRandomSpi {
+  public static class LinuxPRNGSecureRandom extends SecureRandomSpi {
 
         /*
          * IMPLEMENTATION NOTE: Requests to generate bytes and to mix in a seed
@@ -242,7 +245,10 @@ public final class PRNGFixes {
      * each instance needs to seed itself if the client does not explicitly
      * seed it.
      */
-    private boolean mSeeded;
+    private boolean mSeeded = false;
+
+    public LinuxPRNGSecureRandom() {
+    }
 
     @Override
     protected void engineSetSeed(byte[] bytes) {


### PR DESCRIPTION
Main issue is the permissions check-in -- the implementation class needed to be public.
Upon reviewing the code, the invoke() method was redone to eliminate potential misinterpretation of the Varargs argument which could have defeated the entire point of this patch.
