### PR TITLE
Development

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/logging/desktop/WebLoggerDesktopFactoryImpl.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/logging/desktop/WebLoggerDesktopFactoryImpl.java
@@ -42,39 +42,39 @@ public class WebLoggerDesktopFactoryImpl implements WebLoggerFactoryIf {
     }
 
     public void log(int severity, String t, String logMsg) {
-      Logger.getGlobal().log(Level.INFO, t, "N:" + severity + "/" + logMsg);
+      Logger.getGlobal().log(Level.INFO, t + ": " + "N:" + severity + "/" + logMsg);
     }
 
     public void a(String t, String logMsg) {
-      Logger.getGlobal().log(Level.FINEST, t, logMsg);
+      Logger.getGlobal().log(Level.FINEST, t + ": " + logMsg);
     }
 
     public void t(String t, String logMsg) {
-      Logger.getGlobal().log(Level.FINER, t, "Trace/" + logMsg);
+      Logger.getGlobal().log(Level.FINER, t + ": " + "Trace/" + logMsg);
     }
 
     public void v(String t, String logMsg) {
-      Logger.getGlobal().log(Level.FINER, t, "Verbose/" + logMsg);
+      Logger.getGlobal().log(Level.FINER, t + ": " + "Verbose/" + logMsg);
     }
 
     public void d(String t, String logMsg) {
-      Logger.getGlobal().log(Level.FINE, t, logMsg);
+      Logger.getGlobal().log(Level.FINE, t + ": " + logMsg);
     }
 
     public void i(String t, String logMsg) {
-      Logger.getGlobal().log(Level.INFO, t, logMsg);
+      Logger.getGlobal().log(Level.INFO, t + ": " + logMsg);
     }
 
     public void w(String t, String logMsg) {
-      Logger.getGlobal().log(Level.WARNING, t, logMsg);
+      Logger.getGlobal().log(Level.WARNING, t + ": " + logMsg);
     }
 
     public void e(String t, String logMsg) {
-      Logger.getGlobal().log(Level.SEVERE, t, logMsg);
+      Logger.getGlobal().log(Level.SEVERE, t + ": " + logMsg);
     }
 
     public void s(String t, String logMsg) {
-      Logger.getGlobal().log(Level.INFO, t, "Success/" + logMsg);
+      Logger.getGlobal().log(Level.INFO, t + ": " + "Success/" + logMsg);
     }
 
     public void printStackTrace(Throwable e) {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/properties/PropertiesSingleton.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/properties/PropertiesSingleton.java
@@ -599,6 +599,7 @@ public class PropertiesSingleton {
         if (configFile.exists()) {
           configFileInputStream = new FileInputStream(configFile);
 
+          mGeneralProps.clear();
           mGeneralProps.loadFromXML(configFileInputStream);
         }
       } catch (Exception e) {
@@ -624,6 +625,7 @@ public class PropertiesSingleton {
           if (configFile.exists()) {
             configFileInputStream = new FileInputStream(configFile);
 
+            mGlobalDeviceProps.clear();
             mGlobalDeviceProps.loadFromXML(configFileInputStream);
           }
         } catch (Exception e) {
@@ -648,6 +650,7 @@ public class PropertiesSingleton {
         if (configFile.exists()) {
           configFileInputStream = new FileInputStream(configFile);
 
+          mDeviceProps.clear();
           mDeviceProps.loadFromXML(configFileInputStream);
         }
       } catch (Exception e) {
@@ -671,6 +674,7 @@ public class PropertiesSingleton {
           if (configFile.exists()) {
             configFileInputStream = new FileInputStream(configFile);
 
+            mSecureProps.clear();
             mSecureProps.loadFromXML(configFileInputStream);
           }
         } catch (Exception e) {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/LocalizationUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/LocalizationUtils.java
@@ -15,13 +15,11 @@
  */
 package org.opendatakit.utilities;
 
-import android.os.Build;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.io.Charsets;
 import org.opendatakit.logging.WebLogger;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,11 +63,7 @@ public final class LocalizationUtils {
         String value;
         try {
           stream = new FileInputStream(commonFile);
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-          } else {
-            reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
-          }
+          reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
           int ch = reader.read();
           while (ch != -1 && ch != '{') {
             ch = reader.read();
@@ -119,11 +113,7 @@ public final class LocalizationUtils {
         BufferedReader reader = null;
         try {
           stream = new FileInputStream(tableFile);
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-          } else {
-            reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
-          }
+          reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
           reader.mark(1);
           int ch = reader.read();
           while (ch != -1 && ch != '{') {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/ODKFileUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/ODKFileUtils.java
@@ -15,7 +15,6 @@
 
 package org.opendatakit.utilities;
 
-import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.CheckResult;
 import android.util.Log;
@@ -31,7 +30,6 @@ import org.w3c.dom.NodeList;
 
 import java.io.*;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -44,9 +42,14 @@ import java.util.regex.Pattern;
  * @author Carl Hartung (carlhartung@gmail.com)
  */
 public final class ODKFileUtils {
+  /**
+   * A mapper that can read json strings into instances of the given class
+   */
   public static final ObjectMapper mapper = new ObjectMapper();
   // 2nd level -- directories
-  // special filename
+  /**
+   * Filename for the form definition
+   */
   public static final String FORMDEF_JSON_FILENAME = "formDef.json";
 
   // 1st level -- appId
@@ -149,6 +152,8 @@ public final class ODKFileUtils {
    * return null if the file does not exist or is not an
    * accessible uri thru the WebServer. (i.e., the getAsFile() API).
    * used in services/fi.iki.elonen.SimpleWebServer
+   * @param uri The uri to translate
+   * @return A file with the correct path
    */
   @SuppressWarnings("unused")
   public static File fileFromUriOnWebServer(String uri) {
@@ -214,6 +219,9 @@ public final class ODKFileUtils {
     return DATABASE_LOCK_FILE_NAME;
   }
 
+  /**
+   * Throws an exception if there is no sd card available
+   */
   public static void verifyExternalStorageAvailability() {
     String cardstatus = Environment.getExternalStorageState();
     if (cardstatus.equals(Environment.MEDIA_REMOVED) || cardstatus
@@ -247,7 +255,10 @@ public final class ODKFileUtils {
     File dir = new File(path);
     //noinspection SimplifiableIfStatement
     if (dir.exists()) {
-      return true;
+      if (dir.isDirectory()) {
+        return true;
+      }
+      dir.delete();
     }
     return dir.mkdirs();
   }
@@ -278,6 +289,10 @@ public final class ODKFileUtils {
     });
   }
 
+  /**
+   * Makes sure that all the necessary directories exist for the given app name
+   * @param appName the app name to configure
+   */
   public static void assertDirectoryStructure(String appName) {
     String[] dirs = { getAppFolder(appName), getConfigFolder(appName), getDataFolder(appName),
         getOutputFolder(appName), getSystemFolder(appName), getPermanentFolder(appName),
@@ -364,6 +379,12 @@ public final class ODKFileUtils {
     }
   }
 
+  /**
+   * Writes the given tool version to the tool's associated version file
+   * @param appName the app name
+   * @param toolName the name of the tool, used to generate the version file name
+   * @param apkVersion the version to write
+   */
   public static void assertConfiguredToolApp(String appName, String toolName, String apkVersion) {
     writeConfiguredOdkAppVersion(appName, toolName + ".version", apkVersion);
   }
@@ -392,12 +413,8 @@ public final class ODKFileUtils {
     BufferedWriter bw = null;
     try {
       fs = new FileOutputStream(versionFile, false);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        w = new OutputStreamWriter(fs, StandardCharsets.UTF_8);
-      } else {
-        //noinspection deprecation
-        w = new OutputStreamWriter(fs, Charsets.UTF_8);
-      }
+      //noinspection deprecation
+      w = new OutputStreamWriter(fs, Charsets.UTF_8);
       bw = new BufferedWriter(w);
       bw.write(apkVersion);
       bw.write("\n");
@@ -463,12 +480,8 @@ public final class ODKFileUtils {
     BufferedReader br = null;
     try {
       fs = new FileInputStream(versionFile);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-        r = new InputStreamReader(fs, StandardCharsets.UTF_8);
-      } else {
-        //noinspection deprecation
-        r = new InputStreamReader(fs, Charsets.UTF_8);
-      }
+      //noinspection deprecation
+      r = new InputStreamReader(fs, Charsets.UTF_8);
       br = new BufferedReader(r);
       versionLine = br.readLine();
     } catch (IOException e) {
@@ -515,6 +528,11 @@ public final class ODKFileUtils {
     return new File(new File(getOdkFolder()), appPath);
   }
 
+  /**
+   * Gets the folder that contains all the configuration for a particular app
+   * @param appName the app name
+   * @return opendatakit/:app_name
+   */
   public static String getAppFolder(String appName) {
     return getOdkFolder() + File.separator + appName;
   }
@@ -571,10 +589,20 @@ public final class ODKFileUtils {
   //////////////////////////////////////////////////////////
   // Everything under config folder
 
+  /**
+   * Gets the folder with the static app configuration data
+   * @param appName the app name
+   * @return :app_name/config/assets
+   */
   public static String getAssetsFolder(String appName) {
     return getConfigFolder(appName) + File.separator + ASSETS_FOLDER_NAME;
   }
 
+  /**
+   * Gets the folder with the csv files to import on first run
+   * @param appName the app name
+   * @return :app_name/config/assets/csv
+   */
   public static String getAssetsCsvFolder(String appName) {
     return getAssetsFolder(appName) + File.separator + CSV_FOLDER_NAME;
   }
@@ -723,6 +751,13 @@ public final class ODKFileUtils {
     return getTablesFolder(appName, tableId) + File.separator + FORMS_FOLDER_NAME;
   }
 
+  /**
+   * Gets the form folder for the given app, table and form id, contains the formDef.json file
+   * @param appName the app name
+   * @param tableId the table associated with the form
+   * @param formId the form to get the folder for
+   * @return :app_name/config/tables/:table_id/forms/:form_id/
+   */
   public static String getFormFolder(String appName, String tableId, String formId) {
     if (formId == null || formId.isEmpty()) {
       throw new IllegalArgumentException("getFormFolder: formId is null or the empty string!");
@@ -738,6 +773,12 @@ public final class ODKFileUtils {
   /////////////////////////////////////////////////////////
   // Everything under data folder
 
+  /**
+   * Returns the filename that contains the status for whether tables has finished its one time
+   * setup or not
+   * @param appName the app name
+   * @return :app_name/data/tables.init
+   */
   public static String getTablesInitializationCompleteMarkerFile(String appName) {
     return getDataFolder(appName) + File.separator + ODK_TABLES_INIT_FILENAME;
   }
@@ -1110,6 +1151,12 @@ public final class ODKFileUtils {
 
   }
 
+  /**
+   * Returns the requested file as a part of a Uri object
+   * @param appName the app name
+   * @param fileUnderAppName a file with a path inside /sdcard/opendatakit/:app_name
+   * @return the filename represented as an encoded part of a uri fragment
+   */
   public static String asUriFragment(String appName, File fileUnderAppName) {
     String relativePath = asRelativePath(appName, fileUnderAppName);
     String separatorString;
@@ -1239,6 +1286,12 @@ public final class ODKFileUtils {
     return ".." + File.separator + ODKFileUtils.SYSTEM_FOLDER_NAME;
   }
 
+  /**
+   * Gets the md5sum of the given file with the correct prefix
+   * @param appName the app name
+   * @param file the file to md5
+   * @return md5:(:the hash of the file)
+   */
   public static String getMd5Hash(String appName, File file) {
     return MD5_COLON_PREFIX + getNakedMd5Hash(appName, file);
   }
@@ -1379,6 +1432,12 @@ public final class ODKFileUtils {
     return text;
   }
 
+  /**
+   * Copies the given directory, see {@link FileUtils#copyDirectory}
+   * @param sourceFolder the directory to copy
+   * @param destinationFolder where to copy it to
+   * @throws IOException if the action couldn't be completed
+   */
   public static void copyDirectory(File sourceFolder, File destinationFolder) throws IOException {
     ContextClassLoaderWrapper wrapper = new ContextClassLoaderWrapper();
     try {
@@ -1388,6 +1447,12 @@ public final class ODKFileUtils {
     }
   }
 
+  /**
+   * Moves the given directory, see {@link FileUtils#moveDirectory}
+   * @param sourceFolder the directory to move
+   * @param destinationFolder where to move it to
+   * @throws IOException if the action couldn't be completed
+   */
   public static void moveDirectory(File sourceFolder, File destinationFolder) throws IOException {
     ContextClassLoaderWrapper wrapper = new ContextClassLoaderWrapper();
     try {
@@ -1397,6 +1462,13 @@ public final class ODKFileUtils {
     }
   }
 
+  /**
+   * Returns true if the given directory contains the file. See {@link FileUtils#directoryContains}
+   * @param folder the directory that may or may not contain the file
+   * @param file the file that may or may not be under the given folder
+   * @return whether the file is in the passed directory
+   * @throws IOException if the action couldn't be completed
+   */
   public static boolean directoryContains(File folder, File file) throws IOException {
     ContextClassLoaderWrapper wrapper = new ContextClassLoaderWrapper();
     try {
@@ -1406,6 +1478,11 @@ public final class ODKFileUtils {
     }
   }
 
+  /**
+   * Deletes the given folder. See {@link FileUtils#deleteDirectory}
+   * @param folder the folder to delete
+   * @throws IOException if the action couldn't be completed
+   */
   public static void deleteDirectory(File folder) throws IOException {
     ContextClassLoaderWrapper wrapper = new ContextClassLoaderWrapper();
     try {
@@ -1415,6 +1492,12 @@ public final class ODKFileUtils {
     }
   }
 
+  /**
+   * Copies the given file, see {@link FileUtils#copyFile}
+   * @param sourceFile the file to copy
+   * @param destinationFile where to move it to
+   * @throws IOException if the action couldn't be completed
+   */
   public static void copyFile(File sourceFile, File destinationFile) throws IOException {
     ContextClassLoaderWrapper wrapper = new ContextClassLoaderWrapper();
     try {


### PR DESCRIPTION
Aug 17: Add comments... - this removes Build.VERSION tests that avoid Charsets usage but don't actually avoid the compile warnings. If this is a big concern, we should save a UTF_8 charset in ODKFileUtils as a public static final and reference that everywhere.

Aug 24: fix and revert... - This is the fix and reversion of a work-around for the properties singleton and the occasional failure to detect when initialization is required. This is the significant code change to review.

Aug 24: correct desktop logging... - This is a fix that only gets exercised in desktop (website) operations. The argument list for logging was not correct.
