### PR TITLE
fix: url escape treatment

### DIFF
--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/utilities/ODKFileUtilsTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/utilities/ODKFileUtilsTest.java
@@ -1,0 +1,119 @@
+package org.opendatakit.utilities;
+
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for ODKFileUtils
+ */
+
+@RunWith(AndroidJUnit4.class)
+public class ODKFileUtilsTest {
+  static final String appName;
+  static final File appDir;
+  static {
+    appName = "ODKFileUtilsTest";
+    appDir = new File(ODKFileUtils.getAppFolder(appName));
+  }
+
+  @Test
+  public void verifyUriEscapes() {
+
+    // the Uri class doesn't do any fancy encoding for most characters
+
+    File specialFile;
+    String frag;
+    specialFile = new File(appDir, "space name" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name", frag);
+
+    specialFile = new File(specialFile, "space name" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name/space%20name", frag);
+
+    specialFile = new File(appDir, "space name:[]@!$&'()*+,;=" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name%3A%5B%5D%40!%24%26'()*%2B%2C%3B%3D", frag);
+
+    specialFile = new File(appDir, "space name:[]@!$&'()*+,;=\\foo%2Fbar" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name%3A%5B%5D%40!%24%26'()*%2B%2C%3B%3D%5Cfoo%252Fbar", frag);
+
+    specialFile = new File(appDir, "space name?" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name%3F", frag);
+
+    specialFile = new File(appDir, "space name#" );
+    frag = ODKFileUtils.asUriFragment(appName, specialFile);
+    assertEquals("space%20name%23", frag);
+  }
+
+  @Test
+  public void decodeUriEscapes() {
+
+    ODKFileUtils.assertDirectoryStructure(appName);
+    File specialFile;
+    String frag;
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space%20name");
+    frag = specialFile.getName();
+    assertEquals("space name", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space%20name/space%20name");
+    frag = specialFile.getName();
+    assertEquals("space name", frag);
+    frag = specialFile.getParentFile().getName();
+    assertEquals("space name", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name/space name");
+    frag = specialFile.getName();
+    assertEquals("space name", frag);
+    frag = specialFile.getParentFile().getName();
+    assertEquals("space name", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name:[]@!$&'()*+,;=" );
+    frag = specialFile.getName();
+    assertEquals("space name:[]@!$&'()*+,;=", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" +
+        "space%20name%3A%5B%5D%40!%24%26'()*%2B%2C%3B%3D" );
+    frag = specialFile.getName();
+    assertEquals("space name:[]@!$&'()*+,;=", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name?" );
+    frag = specialFile.getName();
+    assertEquals("space name?", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space%20name%3F" );
+    frag = specialFile.getName();
+    assertEquals("space name?", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name#" );
+    frag = specialFile.getName();
+    assertEquals("space name#", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space%20name%23" );
+    frag = specialFile.getName();
+    assertEquals("space name#", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name:[]@!$&'()*+,;=\\foo//bar" );
+    frag = specialFile.getName();
+    assertEquals("bar", frag);
+    frag = specialFile.getParentFile().getName();
+    assertEquals("space name:[]@!$&'()*+,;=\\foo", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space name:[]@!$&'%28%29*+,;=\\foo//bar" );
+    frag = specialFile.getName();
+    assertEquals("bar", frag);
+    frag = specialFile.getParentFile().getName();
+    assertEquals("space name:[]@!$&'()*+,;=\\foo", frag);
+
+    specialFile = ODKFileUtils.getAsFile(appName, appName + "/" + "space%20name%3A%5B%5D%40!%24%26'()*%2B%2C%3B%3D%5Cfoo%252Fbar" );
+    frag = specialFile.getName();
+    assertEquals("space name:[]@!$&'()*+,;=\\foo%2Fbar", frag);
+  }
+}

--- a/androidlibrary_lib/src/main/java/org/opendatakit/consts/WebkitServerConsts.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/consts/WebkitServerConsts.java
@@ -19,6 +19,7 @@ public class WebkitServerConsts {
   public static final String WEBKITSERVER_SERVICE_PACKAGE = "org.opendatakit.services";
   public static final String WEBKITSERVER_SERVICE_CLASS = "org.opendatakit.services.webkitservice.service.OdkWebkitServerService";
 
+  public static final String SCHEME = "http";
   public static final String HOSTNAME = "localhost";
   public static final int PORT = 8635; // 8ODK
 


### PR DESCRIPTION
Our logic had assumed that all filenames did not require escapes (e.g., UTF-8 characters, no special characters). This change should support UTF-8 filenames (e.g., Chinese).

This fix expects all filenames that will be used in urls are converted to URLs via

UrlUtils.getAsWebViewUri(appName, ODKFileUtils.asUriFragment(appName, File))

Coordinated with changes in androidcommon, tables and survey.
