### PR TITLE
Additional runtime permission checks

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/consts/IntentConsts.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/consts/IntentConsts.java
@@ -26,6 +26,8 @@ public class IntentConsts {
 
   public static final String INTENT_KEY_SETTINGS_IN_ADMIN_MODE = "adminMode";
   public static final String INTENT_KEY_SETTINGS_ADMIN_ENABLED = "adminEnabled";
+
+  public static final String INTENT_KEY_PERMISSION_ONLY = "permissionOnly";
   /**
    * Intent Extras:
    * <ol><li>INTENT_KEY_APP_NAME</li>
@@ -91,5 +93,14 @@ public class IntentConsts {
     public static final String SURVEY_PACKAGE_NAME = "org.opendatakit.survey";
     public static final String SURVEY_MAIN_MENU_ACTIVITY_COMPONENT_NAME = "org.opendatakit.survey"
         + ".activities.SplashScreenActivity";
+  }
+
+  /**
+   * Intent Extras:
+   * <ol><li>INTENT_KEY_PERMISSION_ONLY</li></ol>
+   */
+  public class Services {
+    public static final String PACKAGE_NAME = "org.opendatakit.services";
+    public static final String MAIN_ACTIVITY = "org.opendatakit.services.MainActivity";
   }
 }

--- a/androidlibrary_lib/src/main/java/org/opendatakit/consts/RequestCodeConsts.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/consts/RequestCodeConsts.java
@@ -84,6 +84,10 @@ public class RequestCodeConsts {
          * activity
          */
         public static final int LAUNCH_COLUMN_PREFS = 23;
+        /**
+         * Used to launch the main activity to let the user grant Services permissions
+         */
+        public static final int LAUNCH_MAIN_ACTIVITY = 24;
 
         /**
          * Do not instantiate this class

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/RuntimePermissionUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/RuntimePermissionUtils.java
@@ -3,6 +3,7 @@ package org.opendatakit.utilities;
 import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
@@ -37,6 +38,34 @@ public class RuntimePermissionUtils {
     }
 
     return true;
+  }
+
+  public static boolean checkPackageAnyPermission(@NonNull Context context,
+                                              @NonNull String pkgName,
+                                              @NonNull String... permissions) {
+    PackageManager pm = context.getPackageManager();
+
+    for (String permission : permissions) {
+      if (pm.checkPermission(permission, pkgName) == PackageManager.PERMISSION_GRANTED) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public static boolean checkPackageAllPermission(@NonNull Context context,
+                                                  @NonNull String pkgName,
+                                                  @NonNull String... permissions) {
+    PackageManager pm = context.getPackageManager();
+
+    for (String permission : permissions) {
+      if (pm.checkPermission(permission, pkgName) != PackageManager.PERMISSION_GRANTED) {
+        return false;
+      }
+    }
+
+    return false;
   }
 
   public static boolean shouldShowAnyPermissionRationale(@NonNull Activity activity,


### PR DESCRIPTION
Let `BaseLauncherActivity` launch Services to get permissions. 

 - Adds utility methods for checking permissions of any app using package name.
 - Adds intent constants used in `BaseLauncherActivity` to launch Services