### PR TITLE
restructure: move form discovery into ODK Services

### DIFF
--- a/androidlibrary_lib/src/main/aidl/org/opendatakit/database/service/AidlDbInterface.aidl
+++ b/androidlibrary_lib/src/main/aidl/org/opendatakit/database/service/AidlDbInterface.aidl
@@ -272,6 +272,17 @@ interface AidlDbInterface {
       in List<KeyValueStoreEntry> metaData, in boolean clear);
 
   /**
+   * Rescan the config directory tree of the given tableId and update the forms table
+   * with revised information from the formDef.json files that it contains.
+   *
+   * @param appName
+   * @param dbHandleName
+   * @param tableId
+   * @return true if there were no problems
+   */
+  boolean rescanTableFormDefs(in String appName, in DbHandle dbHandleName, in String tableId);
+
+  /**
    * Drop the given tableId and remove all the files (both configuration and
    * data attachments) associated with that table.
    * 

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/service/InternalUserDbInterface.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/service/InternalUserDbInterface.java
@@ -110,6 +110,10 @@ public interface InternalUserDbInterface {
        throws IllegalStateException, IllegalArgumentException, SQLiteException,
        ServicesAvailabilityException;
 
+   boolean rescanTableFormDefs(String appName, DbHandle dbHandleName, String tableId)
+        throws IllegalStateException, IllegalArgumentException, SQLiteException,
+        ServicesAvailabilityException;
+
    void deleteTableMetadata(String appName, DbHandle dbHandleName, String tableId, String partition,
                             String aspect, String key)
        throws IllegalStateException, IllegalArgumentException, SQLiteException,

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/service/InternalUserDbInterfaceAidlWrapperImpl.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/service/InternalUserDbInterfaceAidlWrapperImpl.java
@@ -557,6 +557,26 @@ public class InternalUserDbInterfaceAidlWrapperImpl implements InternalUserDbInt
   }
 
   /**
+   * Rescan the config directory tree of the given tableId and update the forms table
+   * with revised information from the formDef.json files that it contains.
+   *
+   * @param appName
+   * @param dbHandleName
+   * @param tableId
+   * @return true if there were no problems
+   */
+  @Override
+  public boolean rescanTableFormDefs(String appName, DbHandle dbHandleName, String tableId)
+      throws ServicesAvailabilityException {
+    try {
+      return dbInterface.rescanTableFormDefs(appName, dbHandleName, tableId);
+    } catch (Exception e) {
+      rethrowAlwaysAllowedRemoteException(e);
+      throw new IllegalStateException("unreachable - keep IDE happy");
+    }
+  }
+
+  /**
    * The deletion filter includes all non-null arguments. If all arguments
    * (except the db) are null, then all properties are removed.
    *

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/service/UserDbInterface.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/service/UserDbInterface.java
@@ -339,6 +339,18 @@ public interface UserDbInterface {
       throws ServicesAvailabilityException;
 
   /**
+   * Rescan the config directory tree of the given tableId and update the forms table
+   * with revised information from the formDef.json files that it contains.
+   *
+   * @param appName
+   * @param dbHandleName
+   * @param tableId
+   * @return true if there were no problems
+   */
+  boolean rescanTableFormDefs(String appName, DbHandle dbHandleName, String tableId)
+      throws ServicesAvailabilityException;
+
+  /**
    * The deletion filter includes all non-null arguments. If all arguments
    * (except the db) are null, then all properties are removed.
    *

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/service/UserDbInterfaceImpl.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/service/UserDbInterfaceImpl.java
@@ -527,6 +527,22 @@ public class UserDbInterfaceImpl implements UserDbInterface {
   }
 
   /**
+   * Rescan the config directory tree of the given tableId and update the forms table
+   * with revised information from the formDef.json files that it contains.
+   *
+   * @param appName
+   * @param dbHandleName
+   * @param tableId
+   * @return true if there were no problems
+   */
+  @Override
+  public boolean rescanTableFormDefs(String appName, DbHandle dbHandleName, String tableId)
+      throws ServicesAvailabilityException {
+
+    return internalUserDbInterface.rescanTableFormDefs(appName, dbHandleName, tableId);
+  }
+
+  /**
    * The deletion filter includes all non-null arguments. If all arguments
    * (except the db) are null, then all properties are removed.
    *

--- a/androidlibrary_lib/src/main/res/values-es/strings.xml
+++ b/androidlibrary_lib/src/main/res/values-es/strings.xml
@@ -64,9 +64,10 @@
     <string name="import_in_progress">Importando fila %1$d de acerca de %2$d</string>
 
     <string name="searching_for_form_defs">Buscando impresos nuevos &#8230;</string>
-    <string name="updating_form_information">Leyendo definición de impreso %1$s (%2$d de %3$d)</string>
-    <string name="form_register_success">Leído con éxito: impreso %2$s para la tabula %1$s</string>
-    <string name="form_register_failure">Error al leer: impreso %2$s para la tabula %1$s</string>
+    <string name="updating_table_form_information"
+    >Leyendo definición de impreso de tabula %1$s (%2$d de %3$d)</string>
+    <string name="table_forms_register_success">Leído con éxito: impreso de tabula %1$s</string>
+    <string name="table_forms_register_failure">Error al leer: impreso de tabula %1$s</string>
 
     <string name="abort_error_accessing_database">Abortado: Error al acceder baso de datos</string>
 </resources>

--- a/androidlibrary_lib/src/main/res/values/strings.xml
+++ b/androidlibrary_lib/src/main/res/values/strings.xml
@@ -64,9 +64,10 @@
 	<string name="import_in_progress">Importing row %1$d of about %2$d</string>
 
 	<string name="searching_for_form_defs">Searching for new form definitions &#8230;</string>
-	<string name="updating_form_information">Updating form information for form %1$s (%2$d of %3$d)</string>
-	<string name="form_register_success">Success: Defining formId %2$s for tableId %1$s</string>
-	<string name="form_register_failure">Failure: Defining formId %2$s for tableId %1$s</string>
+	<string
+name="updating_table_form_information">Updating form information for table %1$s (%2$d of %3$d)</string>
+	<string name="table_forms_register_success">Success: Processed forms for tableId %1$s</string>
+	<string name="table_forms_register_failure">Failure: Processing forms for tableId %1$s</string>
 
 	<string name="abort_error_accessing_database">Aborted: Error accessing database</string>
 


### PR DESCRIPTION
Add API rescanTableFormDefs(...tableId) to database AIDL. This scans the given tableId directory looking for form definitions and ensures that the _formDefs table matches that content (either adding or removing entries, as appropriate).

Change InitializationUtil to:
(1) updateTableDirs() -- remove tableIds that are no longer present on the sdcard.
(2) updateFormDirs() -- make use of this new database API. This shrinks this routine into just retrieving the tableIds from the database and iterating over them, invoking the new API. The directory scanning is handled within the ODK Services layer.
restructure: move form discovery into ODK Services