### PR TITLE
lint clean-up and changes for Windows and prep fo rmoving SyncNotification class

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/builder/CsvUtil.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/builder/CsvUtil.java
@@ -51,11 +51,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 /**

--- a/androidlibrary_lib/src/main/java/org/opendatakit/builder/InitializationUtil.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/builder/InitializationUtil.java
@@ -14,25 +14,33 @@
 
 package org.opendatakit.builder;
 
-import android.content.ContentValues;
-import android.content.Context;
-import android.content.res.Resources;
-import android.database.Cursor;
-import android.net.Uri;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
 import org.opendatakit.androidlibrary.R;
 import org.opendatakit.database.service.DbHandle;
-import org.opendatakit.database.utilities.CursorUtils;
 import org.opendatakit.exception.ServicesAvailabilityException;
 import org.opendatakit.listener.ImportListener;
 import org.opendatakit.logging.WebLogger;
-import org.opendatakit.provider.FormsColumns;
-import org.opendatakit.provider.FormsProviderAPI;
 import org.opendatakit.utilities.ODKFileUtils;
 
-import java.io.*;
-import java.util.*;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import android.content.Context;
+import android.content.res.Resources;
 
 /**
  * Background task for exploding the built-in zipfile resource into the
@@ -398,9 +406,10 @@ public class InitializationUtil {
         CsvUtil cu = new CsvUtil(getSupervisor(), appName);
         for (String key : keys) {
           curFileCount++;
-          String filename = prop.getProperty(key + KEY_SUFFIX_CSV_FILENAME);
+          String srcFilename = prop.getProperty(key + KEY_SUFFIX_CSV_FILENAME);
           //this.importStatus.put(key, false);
-          file = new File(ODKFileUtils.getAppFolder(appName), filename);
+          file = new File(ODKFileUtils.getAppFolder(appName), srcFilename);
+          String filename = ODKFileUtils.asRelativePath(appName, file);
           mKeyToFileMap.put(key, filename);
           if (!file.exists()) {
             pendingOutcome.assetsCsvFileNotFoundSet.add(key);

--- a/androidlibrary_lib/src/main/java/org/opendatakit/consts/CharsetConsts.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/consts/CharsetConsts.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 University of Washington
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.opendatakit.consts;
+
+import java.nio.charset.Charset;
+
+/**
+ * Added to suppress warnings about Charsets.UTF_8 deprecation
+ *
+ * @author mitchellsundt@gmail.com
+ */
+
+public class CharsetConsts {
+  public static final Charset UTF_8 = Charset.forName("UTF-8");
+}

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/data/ColumnDefinition.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/data/ColumnDefinition.java
@@ -16,8 +16,6 @@
 package org.opendatakit.database.data;
 
 import android.support.annotation.NonNull;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.opendatakit.aggregate.odktables.rest.ElementDataType;
 import org.opendatakit.aggregate.odktables.rest.ElementType;
 import org.opendatakit.aggregate.odktables.rest.entity.Column;

--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AboutMenuFragment.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AboutMenuFragment.java
@@ -62,6 +62,18 @@ public class AboutMenuFragment extends Fragment implements LicenseReaderListener
    */
   private String mLicenseText = null;
 
+  @SuppressWarnings("deprecation")
+  private Spanned licenseTextFormattedAsHtml() {
+    Spanned html;
+    if (Build.VERSION.SDK_INT >= 24) {
+      html = Html.fromHtml(mLicenseText, Html.FROM_HTML_MODE_LEGACY);
+    } else {
+      //noinspection deprecation
+      html = Html.fromHtml(mLicenseText);
+    }
+    return html;
+  }
+
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
@@ -108,13 +120,7 @@ public class AboutMenuFragment extends Fragment implements LicenseReaderListener
 
     if (savedInstanceState != null && savedInstanceState.containsKey(LICENSE_TEXT)) {
       mLicenseText = savedInstanceState.getString(LICENSE_TEXT);
-      Spanned html;
-      if (Build.VERSION.SDK_INT >= 24) {
-        html = Html.fromHtml(mLicenseText, Html.FROM_HTML_MODE_LEGACY);
-      } else {
-        //noinspection deprecation
-        html = Html.fromHtml(mLicenseText);
-      }
+      Spanned html = licenseTextFormattedAsHtml();
       mTextView.setText(html);
     } else {
       readLicenseFile();
@@ -130,19 +136,14 @@ public class AboutMenuFragment extends Fragment implements LicenseReaderListener
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void readLicenseComplete(String result) {
     IAppAwareActivity activity = (IAppAwareActivity) getActivity();
     WebLogger.getLogger(activity.getAppName()).i(TAG, "Read license complete");
     if (result != null) {
       // Read license file successfully
       mLicenseText = result;
-      Spanned html;
-      if (Build.VERSION.SDK_INT >= 24) {
-        html = Html.fromHtml(result, Html.FROM_HTML_MODE_LEGACY);
-      } else {
-        //noinspection deprecation
-        html = Html.fromHtml(result);
-      }
+      Spanned html = licenseTextFormattedAsHtml();
       mTextView.setText(html);
     } else {
       // had some failures

--- a/androidlibrary_lib/src/main/java/org/opendatakit/properties/PropertiesSingletonFactory.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/properties/PropertiesSingletonFactory.java
@@ -63,10 +63,11 @@ abstract class PropertiesSingletonFactory {
     }
 
     if ( gSingleton == null || gAppName == null || !gAppName.equals(appName) ) {
+      // verify of directories needs to occur before we create the singleton.
+      verifyDirectories(appName);
       gSingleton = new PropertiesSingleton(context, appName, mGeneralDefaults, mDeviceDefaults,
         mSecureDefaults);
       gAppName = appName;
-      verifyDirectories(appName);
     }
     return gSingleton;
   }

--- a/androidlibrary_lib/src/main/java/org/opendatakit/sync/service/SyncProgressEvent.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/sync/service/SyncProgressEvent.java
@@ -30,7 +30,7 @@ public class SyncProgressEvent implements Parcelable {
   @SuppressWarnings("WeakerAccess")
   public final int maxProgressBar;
 
-  protected SyncProgressEvent(String progressMessageText, SyncProgressState progressState,
+  public SyncProgressEvent(String progressMessageText, SyncProgressState progressState,
       int curProgressBar, int maxProgressBar) {
     this.progressMessageText = progressMessageText;
     this.progressState = progressState;

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/LocalizationUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/LocalizationUtils.java
@@ -16,7 +16,7 @@
 package org.opendatakit.utilities;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.io.Charsets;
+import org.opendatakit.consts.CharsetConsts;
 import org.opendatakit.logging.WebLogger;
 
 import java.io.*;
@@ -63,7 +63,7 @@ public final class LocalizationUtils {
         String value;
         try {
           stream = new FileInputStream(commonFile);
-          reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
+          reader = new BufferedReader(new InputStreamReader(stream, CharsetConsts.UTF_8));
           int ch = reader.read();
           while (ch != -1 && ch != '{') {
             ch = reader.read();
@@ -113,7 +113,7 @@ public final class LocalizationUtils {
         BufferedReader reader = null;
         try {
           stream = new FileInputStream(tableFile);
-          reader = new BufferedReader(new InputStreamReader(stream, Charsets.UTF_8));
+          reader = new BufferedReader(new InputStreamReader(stream, CharsetConsts.UTF_8));
           reader.mark(1);
           int ch = reader.read();
           while (ch != -1 && ch != '{') {

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/ODKFileUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/ODKFileUtils.java
@@ -20,11 +20,10 @@ import android.os.Environment;
 import android.support.annotation.CheckResult;
 import android.util.Log;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.lang3.CharEncoding;
-import org.opendatakit.consts.WebkitServerConsts;
+import org.opendatakit.consts.CharsetConsts;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.provider.FormsColumns;
 import org.w3c.dom.Node;
@@ -142,6 +141,15 @@ public final class ODKFileUtils {
   private static final Pattern VALID_FOLDER_PATTERN = Pattern
       .compile("^\\p{L}\\p{M}*(\\p{L}\\p{M}*|\\p{Nd}|_)+$");
 
+  private static final Pattern FORWARD_SLASH_PATTERN = Pattern.compile("/");
+  private static final Pattern FILE_SEPARATOR_PATTERN;
+  static {
+	  if ( File.separator.equals("/") ) {
+		  FILE_SEPARATOR_PATTERN = Pattern.compile(File.separator);
+	  } else {
+		  FILE_SEPARATOR_PATTERN = Pattern.compile(File.separator + File.separator);
+	  }
+  }
   /**
    * Do not instantiate this class
    */
@@ -183,7 +191,7 @@ public final class ODKFileUtils {
       return null;
     }
 
-    String[] parts = uriFragment.split("/");
+    String[] parts = FORWARD_SLASH_PATTERN.split(uriFragment);
     if (parts.length > 1) {
       switch (parts[0]) {
       case CONFIG_FOLDER_NAME:
@@ -417,7 +425,7 @@ public final class ODKFileUtils {
     try {
       fs = new FileOutputStream(versionFile, false);
       //noinspection deprecation
-      w = new OutputStreamWriter(fs, Charsets.UTF_8);
+      w = new OutputStreamWriter(fs, CharsetConsts.UTF_8);
       bw = new BufferedWriter(w);
       bw.write(apkVersion);
       bw.write("\n");
@@ -484,7 +492,7 @@ public final class ODKFileUtils {
     try {
       fs = new FileInputStream(versionFile);
       //noinspection deprecation
-      r = new InputStreamReader(fs, Charsets.UTF_8);
+      r = new InputStreamReader(fs, CharsetConsts.UTF_8);
       br = new BufferedReader(r);
       versionLine = br.readLine();
     } catch (IOException e) {
@@ -524,7 +532,7 @@ public final class ODKFileUtils {
   }
 
   private static File fromAppPath(String appPath) {
-    String[] terms = appPath.split(File.separator);
+    String[] terms = FILE_SEPARATOR_PATTERN.split(appPath);
     if (terms.length < 1) {
       return null;
     }


### PR DESCRIPTION
1. remove unused imports

2. Add CharsetConsts for lint warning. Replace use of Charsets.UTF_8 everywhere with the one we define there.
 
3. Misc. fiddly path-parsing changes for Windows

4. isolate license text Html parsing and add deprecation warning suppression.

5. change visibility of constructor. This enables moving the sync notification class into a different package.
