### PR TITLE
Replace support-v13 ActivityCompat with support-v4 ActivityCompat

### DIFF
--- a/androidlibrary_lib/build.gradle
+++ b/androidlibrary_lib/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     api 'net.jcip:jcip-annotations:1.0'
     api 'com.android.support:support-annotations:27.1.0'
     api 'com.android.support:support-v13:27.1.0'
+    api 'com.android.support:support-v4:27.1.0'
 
     // Testing dependencies
     testImplementation 'junit:junit:4.12'

--- a/androidlibrary_lib/src/main/java/org/opendatakit/utilities/RuntimePermissionUtils.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/utilities/RuntimePermissionUtils.java
@@ -8,7 +8,7 @@ import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
-import android.support.v13.app.ActivityCompat;
+import android.support.v4.app.ActivityCompat;
 import org.opendatakit.androidlibrary.R;
 
 public class RuntimePermissionUtils {


### PR DESCRIPTION
ActivityCompat is deprecated in support library 27.1.0 and replaced by ActivityCompat in support-v4. 
This pull request replaces usage of v13 ActivityCompat with v4 ActivityCompat.