### PR TITLE
Improve Progress/Alert Dialog

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertDialogFragment.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertDialogFragment.java
@@ -230,6 +230,7 @@ public class AlertDialogFragment extends DialogFragment implements DialogInterfa
       if (outputAlertDialogFragment == null) {
          outputAlertDialogFragment = AlertDialogFragment.newInstance(fragmentId, dismissActivity, title, message);
       } else {
+         fragmentManager.executePendingTransactions();
          outputAlertDialogFragment.setTitle(title);
          outputAlertDialogFragment.setMessage(message);
       }

--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/AlertNProgessMsgFragmentMger.java
@@ -355,7 +355,7 @@ public class AlertNProgessMsgFragmentMger {
       progressDialogFragment = ProgressDialogFragment.eitherReuseOrCreateNew(
           progressDialogTag, progressDialogFragment, fragmentManager, currentTitle, currentMessage, progressDismissActivity);
 
-      if(!progressDialogFragment.isAdded()) {
+      if(!progressDialogFragment.isAdded() && !progressDialogFragment.isRemoving()) {
          progressDialogFragment.show(fragmentManager, progressDialogTag);
       }
    }
@@ -380,7 +380,7 @@ public class AlertNProgessMsgFragmentMger {
       alertDialogFragment = AlertDialogFragment.eitherReuseOrCreateNew(alertDialogTag, alertDialogFragment,
           fragmentManager, alertDismissActivity, fragmentId, currentTitle, currentMessage);
 
-      if(!alertDialogFragment.isAdded()) {
+      if(!alertDialogFragment.isAdded() && !alertDialogFragment.isRemoving()) {
          alertDialogFragment.show(fragmentManager, alertDialogTag);
       }
    }

--- a/androidlibrary_lib/src/main/java/org/opendatakit/fragment/ProgressDialogFragment.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/fragment/ProgressDialogFragment.java
@@ -337,6 +337,7 @@ import org.opendatakit.utilities.AppNameUtil;
              .newInstance(title, message, canDismissDialog, positiveButtonText, negativeButtonText,
                  neutralButtonText);
       } else {
+         fragmentManager.executePendingTransactions();
          outputProgressDialogFragment.setTitle(title);
          outputProgressDialogFragment.setMessage(message);
       }


### PR DESCRIPTION
Fix lifecycle related dialog problems.

`executePendingTransactions` makes sure dialog is ready.
`isRemoving` checks if the dialog is in the process of being removed.