### PR TITLE
Fixed TypedRow to properly return null

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/data/BaseTable.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/data/BaseTable.java
@@ -290,7 +290,8 @@ public class BaseTable implements Parcelable {
   }
 
   public Row getRowAtIndex(int index) {
-    return mRows.get(index);
+    boolean inBounds = (index >= 0) && (index < mRows.size());
+    return inBounds ? mRows.get(index) : null;
   }
 
   /**

--- a/androidlibrary_lib/src/main/java/org/opendatakit/database/data/TypedRow.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/database/data/TypedRow.java
@@ -241,6 +241,9 @@ public final class TypedRow implements Parcelable {
       if(dataType == null) {
          return null;
       }
+      if (row == null) {
+         return null;
+      }
       try {
          if (ElementDataType.string.equals(dataType)) {
             return row.getRawStringByKey(key); 


### PR DESCRIPTION
closes opendatakit/tool-suite-X#61

addresses opendatakit/tool-suite-X#61

What is included in this PR?
Fixed the BaseTable and TypedRow classes so that they properly returned null and handled IndexOutOfBounds errors. This is a new PR into the development branch.

What new issues will need to be opened because of this PR?
None

What is left to be done in the addressed issue?
This PR must be concurrently included with the same PR from opendatakit/tables

What problems did you encounter?
None