### PR TITLE
Fix Deprecated AsynTask In LicenseReaderTask

### DIFF
--- a/androidlibrary_lib/src/main/java/org/opendatakit/task/LicenseReaderTask.java
+++ b/androidlibrary_lib/src/main/java/org/opendatakit/task/LicenseReaderTask.java
@@ -16,65 +16,72 @@
 package org.opendatakit.task;
 
 import android.app.Application;
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 import org.opendatakit.androidlibrary.R;
 import org.opendatakit.listener.LicenseReaderListener;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-public class LicenseReaderTask extends AsyncTask<Void, Integer, String> {
+public class LicenseReaderTask {
 
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+  private final Handler handler = new Handler(Looper.getMainLooper());
   private Application appContext;
   private LicenseReaderListener lrl;
   private String appName;
-  private String mResult;
+  private volatile String mResult;
 
-  protected String doInBackground(Void... args) {
 
-    StringBuilder interimResult = null;
+ //execute() Starts the background task to read the license file
+  public void execute() {
+    executorService.execute(() -> {
+      StringBuilder interimResult = new StringBuilder();
+      String result = null;
 
-    try {
-      InputStream licenseInputStream = appContext.getResources().openRawResource(R.raw.license);
-      InputStreamReader licenseInputStreamReader = new InputStreamReader(licenseInputStream);
-      BufferedReader r = new BufferedReader(licenseInputStreamReader);
-      interimResult = new StringBuilder();
-      String line;
-      while ((line = r.readLine()) != null) {
-        interimResult.append(line);
-        interimResult.append("\n");
+      try {
+        InputStream licenseInputStream = appContext.getResources().openRawResource(R.raw.license);
+        InputStreamReader licenseInputStreamReader = new InputStreamReader(licenseInputStream);
+        BufferedReader r = new BufferedReader(licenseInputStreamReader);
+
+        String line;
+        while ((line = r.readLine()) != null) {
+          interimResult.append(line).append("\n");
+        }
+
+        r.close();
+        licenseInputStreamReader.close();
+        licenseInputStream.close();
+
+        result = interimResult.toString();
+      } catch (Exception e) {
+        e.printStackTrace();
       }
-      r.close();
-      licenseInputStreamReader.close();
-      licenseInputStream.close();
 
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return (interimResult == null) ? null : interimResult.toString();
+      String finalResult = result;
+      handler.post(() -> {
+        mResult = finalResult;
+        if (lrl != null) {
+          lrl.readLicenseComplete(finalResult);
+        }
+      });
+    });
   }
 
-  @Override
-  protected void onPostExecute(String result) {
+  //cancel() Stops the background task and notifies the listener (if any)
+  public void cancel() {
     synchronized (this) {
-      mResult = result;
-      appContext = null;
-      if (lrl != null) {
-        lrl.readLicenseComplete(result);
-      }
-    }
-  }
-
-  @Override
-  protected void onCancelled(String result) {
-    synchronized (this) {
-      mResult = result;
-      appContext = null;
-      // can be null if cancelled before task executes
-      if (lrl != null) {
-        lrl.readLicenseComplete(result);
-      }
+      executorService.shutdownNow();
+      handler.post(() -> {
+        // can be null if cancelled before task executes
+        if (lrl != null) {
+          lrl.readLicenseComplete(mResult);
+        }
+      });
     }
   }
 
@@ -116,4 +123,3 @@ public class LicenseReaderTask extends AsyncTask<Void, Integer, String> {
     }
   }
 }
-


### PR DESCRIPTION
[AsynTask](https://developer.android.com/reference/android/os/AsyncTask) is deprecated and not more in use, Replacing with standard `java.util.concurrent` is a good practice and most feasible solution

**New Changes:**

   1. Used an `ExecutorService` with a single thread for background execution
   2. A `Handler` ensures UI updates are done safely on the main thread ( notify the listener on the main thread )
   3. `execute()` Starts the background task to read the license file
   4. `cancel()` Stops the background task and notifies the listener (if any)
   