### PR TITLE
Test coverage for Data Classes

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -15,17 +15,30 @@
 package org.opendatakit.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import android.graphics.Color;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.opendatakit.aggregate.odktables.rest.ElementDataType;
+import org.opendatakit.aggregate.odktables.rest.entity.Column;
+import org.opendatakit.database.data.BaseTable;
+import org.opendatakit.database.data.OrderedColumns;
+import org.opendatakit.database.data.Row;
+import org.opendatakit.database.data.TypedRow;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.logging.desktop.WebLoggerDesktopFactoryImpl;
 import org.opendatakit.utilities.StaticStateManipulator;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
@@ -100,7 +113,7 @@ public class ColorRuleTest {
    //Test to show if the returned Json representation for ColorRule is correct
    @Test
    public void testGetJsonRepresentation(){
-      String ruleId = UUID.randomUUID().toString();
+      String ruleId = generateId();
       ColorRule cr = new ColorRule(ruleId, "myElement1", ColorRule.RuleType.NO_OP, "-1", Color.YELLOW, Color.BLACK);
       TreeMap<String,Object> expected = new TreeMap<>();
       expected.put("mValue", "-1");
@@ -121,4 +134,56 @@ public class ColorRuleTest {
       assertEquals(expected, cr.toString());
    }
 
+   private static final String APP_NAME = "colorRuleTest";
+   private static final String TABLE_ID_1 = "myTableId_1";
+   private static final String COLOR_COL = "Color_Col";
+
+   @Test
+   public void testCheckMatch() {
+      ColorRule cr1 = new ColorRule(generateId(), "myElement1",  ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
+      ColorRule cr2 = new ColorRule(generateId(), "myElement2",  ColorRule.RuleType.LESS_THAN, "2", Color.BLUE, Color.WHITE);
+      ColorRule cr3 = new ColorRule(generateId(), "myElement3",  ColorRule.RuleType.LESS_THAN_OR_EQUAL, "3", Color.BLUE, Color.WHITE);
+      ColorRule cr4 = new ColorRule(generateId(), "myElement4",  ColorRule.RuleType.GREATER_THAN, "4", Color.BLUE, Color.WHITE);
+      ColorRule cr5 = new ColorRule(generateId(), "myElement5",  ColorRule.RuleType.GREATER_THAN_OR_EQUAL, "5", Color.BLUE, Color.WHITE);
+
+      List<Column> columns = new ArrayList<>();
+      columns.add(new Column(COLOR_COL, COLOR_COL, ElementDataType.integer.name(), null));
+      OrderedColumns orderedColumns = new OrderedColumns(APP_NAME, TABLE_ID_1, columns);
+      String[] primaryKeys = {cr1.getRuleId(), cr2.getRuleId(), cr3.getRuleId(), cr4.getRuleId(), cr5.getRuleId()};
+      String[] elementKeys = {"myElement1", "myElement2", "myElement3", "myElement4", "myElement5", "myElement"};
+      BaseTable table = new BaseTable(primaryKeys, elementKeys, generateElementKeyToIndex(elementKeys), 5);
+      Row row;
+      TypedRow rowToMatch;
+      row= new Row(new String[]{"1","1","3","5","5","0"}, table);
+      table.addRow(row);
+      rowToMatch = new TypedRow(table.getRowAtIndex(0),orderedColumns);
+
+      assertTrue(cr1.checkMatch(ElementDataType.integer, rowToMatch));
+      assertTrue(cr2.checkMatch(ElementDataType.integer, rowToMatch));
+      assertTrue(cr3.checkMatch(ElementDataType.integer, rowToMatch));
+      assertTrue(cr4.checkMatch(ElementDataType.integer, rowToMatch));
+      assertTrue(cr5.checkMatch(ElementDataType.integer, rowToMatch));
+
+      row= new Row(new String[]{"0","2","4","4","3"}, table);
+      table.addRow(row);
+      rowToMatch = new TypedRow(table.getRowAtIndex(1),orderedColumns);
+
+      assertFalse(cr1.checkMatch(ElementDataType.integer, rowToMatch));
+      assertFalse(cr2.checkMatch(ElementDataType.integer, rowToMatch));
+      assertFalse(cr3.checkMatch(ElementDataType.integer, rowToMatch));
+      assertFalse(cr4.checkMatch(ElementDataType.integer, rowToMatch));
+      assertFalse(cr5.checkMatch(ElementDataType.integer, rowToMatch));
+   }
+
+   private String generateId(){
+      return UUID.randomUUID().toString();
+   }
+
+   private Map<String, Integer> generateElementKeyToIndex(String[] elementKeys) {
+      Map<String, Integer> elementKeyToIndex = new HashMap<>();
+      for (int i = 0; i < elementKeys.length; i++) {
+         elementKeyToIndex.put(elementKeys[i], i);
+      }
+      return elementKeyToIndex;
+   }
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -14,6 +14,8 @@
 
 package org.opendatakit.data;
 
+import static org.junit.Assert.assertEquals;
+
 import android.graphics.Color;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -23,6 +25,9 @@ import org.junit.runners.JUnit4;
 import org.opendatakit.logging.WebLogger;
 import org.opendatakit.logging.desktop.WebLoggerDesktopFactoryImpl;
 import org.opendatakit.utilities.StaticStateManipulator;
+
+import java.util.TreeMap;
+import java.util.UUID;
 
 @RunWith(JUnit4.class)
 public class ColorRuleTest {
@@ -91,5 +96,19 @@ public class ColorRuleTest {
 
       Assert.assertTrue(cr1.equalsWithoutId(cr2));
    }
+   //Test to show if the returned Json representation for ColorRule is correct
+   @Test
+   public void testGetJsonRepresentation(){
+      String ruleId = UUID.randomUUID().toString();
+      ColorRule cr = new ColorRule(ruleId, "myElement1", ColorRule.RuleType.NO_OP, "-1", Color.YELLOW, Color.BLACK);
+      TreeMap<String,Object> expected = new TreeMap<>();
+      expected.put("mValue", "-1");
+      expected.put("mElementKey", "myElement1");
+      expected.put("mOperator", "NO_OP");
+      expected.put("mId", ruleId);
+      expected.put("mForeground", Color.YELLOW);
+      expected.put("mBackground", Color.BLACK);
 
+      assertEquals(expected, cr.getJsonRepresentation());
+   }
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -23,7 +23,9 @@ import static org.opendatakit.data.ColorRule.RuleType.getValues;
 import android.graphics.Color;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,15 +43,13 @@ import org.opendatakit.utilities.StaticStateManipulator;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 
 @RunWith(JUnit4.class)
 public class ColorRuleTest {
-
    String ruleId = UUID.randomUUID().toString();
-   ColorRule cr = new ColorRule(ruleId, MY_ELEMENT,  ColorRule.RuleType.EQUAL, "1", Color.YELLOW, Color.BLACK);
+   ColorRule cr;
 
    @BeforeClass
    public static void oneTimeSetUp() {
@@ -57,6 +57,14 @@ public class ColorRuleTest {
       WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
    }
 
+   @Before
+   public void setupColorRule(){
+      cr = new ColorRule(ruleId, MY_ELEMENT,  ColorRule.RuleType.EQUAL, "1", Color.YELLOW, Color.BLACK);
+   }
+   @After
+   public void tearDownColorRule(){
+      cr = null;
+   }
    @Test
    public void testColorRule() {
       ColorRule cr1 = new ColorRule("myElement", ColorRule.RuleType.EQUAL, "5", Color.BLUE, Color
@@ -138,8 +146,6 @@ public class ColorRuleTest {
 
       cr.setOperator(ColorRule.RuleType.GREATER_THAN_OR_EQUAL);
       assertEquals(GREATER_THAN_OR_EQUAL_SYMBOL, cr.getOperator().getSymbol());
-
-      cr.setOperator(ColorRule.RuleType.EQUAL);
    }
 
    /**getValues() test.
@@ -213,9 +219,7 @@ public class ColorRuleTest {
     **/
    @Test
    public void givenColorRule_whenStringRequested_thenReturnStringOfAttributesToValuesAssignmentSeparatedByComma() {
-      ColorRule cr = new ColorRule("uuid13", MY_ELEMENT, ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
-      String expected = "[id=uuid13, elementKey=myElement, operator=EQUAL, value=1, background=-1, foreground=-16776961]";
-
+      String expected = "[id="+ruleId+", elementKey=myElement, operator=EQUAL, value=1, background=-16777216, foreground=-256]";
       assertEquals(expected, cr.toString());
    }
 
@@ -241,7 +245,6 @@ public class ColorRuleTest {
       assertTrue(cr.checkMatch(ElementDataType.number, rowToMatch));
       updateColorRule(MY_ELEMENT_6, "true", ColorRule.RuleType.LESS_THAN);
       assertTrue(cr.checkMatch(ElementDataType.bool, rowToMatch));
-      updateColorRule(MY_ELEMENT, "1", ColorRule.RuleType.EQUAL);
    }
 
    /**checkMatch() test.
@@ -276,7 +279,14 @@ public class ColorRuleTest {
       //Setup Color table
       String[] primaryKey = {"id"};
       String[] elementKeys = {MY_ELEMENT_1, MY_ELEMENT_2, MY_ELEMENT_3, MY_ELEMENT_4, MY_ELEMENT_5, MY_ELEMENT_6};
-      BaseTable table = new BaseTable(primaryKey, elementKeys, generateElementKeyToIndex(elementKeys), 1);
+      HashMap<String, Integer> elementKeyToIndex = new HashMap<>();
+      elementKeyToIndex.put(MY_ELEMENT_1,0);
+      elementKeyToIndex.put(MY_ELEMENT_2,1);
+      elementKeyToIndex.put(MY_ELEMENT_3,2);
+      elementKeyToIndex.put(MY_ELEMENT_4,3);
+      elementKeyToIndex.put(MY_ELEMENT_5,4);
+      elementKeyToIndex.put(MY_ELEMENT_6,5);
+      BaseTable table = new BaseTable(primaryKey, elementKeys, elementKeyToIndex, 1);
       //Define the table's column
       List<Column> columns = new ArrayList<>();
       columns.add(new Column(COLOR_COL, COLOR_COL, ElementDataType.integer.name(), null));
@@ -292,17 +302,7 @@ public class ColorRuleTest {
       cr.setVal(value);
       cr.setOperator(operator);
    }
-   private String generateId(){
-      return UUID.randomUUID().toString();
-   }
 
-   private Map<String, Integer> generateElementKeyToIndex(String[] elementKeys) {
-      Map<String, Integer> elementKeyToIndex = new HashMap<>();
-      for (int i = 0; i < elementKeys.length; i++) {
-         elementKeyToIndex.put(elementKeys[i], i);
-      }
-      return elementKeyToIndex;
-   }
    private static final String APP_NAME = "colorRuleTest";
    private static final String TABLE_ID_1 = "myTableId_1";
    private static final String COLOR_COL = "Color_Col";
@@ -318,8 +318,9 @@ public class ColorRuleTest {
    private static final String LESS_THAN_OR_EQUAL_SYMBOL = "<=";
    private static final String GREATER_THAN_OR_EQUAL_SYMBOL = ">=";
    private static final String GREATER_THAN_SYMBOL = ">";
-   @After
-   public void clearProperties() {
+   @AfterClass
+   public static void clearProperties() {
       StaticStateManipulator.get().reset();
+      WebLogger.closeAll();
    }
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -17,6 +17,7 @@ package org.opendatakit.data;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.opendatakit.data.ColorRule.RuleType.getValues;
 
 import android.graphics.Color;
 
@@ -112,12 +113,38 @@ public class ColorRuleTest {
 
    //Test to show if the returned Json representation for ColorRule is correct
    @Test
+   public void testGetSymbol() {
+      assertEquals("=", ColorRule.RuleType.EQUAL.getSymbol());
+   }
+   @Test
+   public void testGetEnumFromString() {
+      CharSequence [] ruleTypeStrings = getValues();
+      ColorRule.RuleType expected = ColorRule.RuleType.LESS_THAN;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(ruleTypeStrings[0].toString()));
+      expected = ColorRule.RuleType.LESS_THAN_OR_EQUAL;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(ruleTypeStrings[1].toString()));
+      expected = ColorRule.RuleType.EQUAL;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(ruleTypeStrings[2].toString()));
+      expected = ColorRule.RuleType.GREATER_THAN_OR_EQUAL;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(ruleTypeStrings[3].toString()));
+      expected = ColorRule.RuleType.GREATER_THAN;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(ruleTypeStrings[4].toString()));
+      expected = ColorRule.RuleType.NO_OP;
+      assertEquals(expected, ColorRule.RuleType.getEnumFromString(""));
+      try {
+         ColorRule.RuleType.getEnumFromString("odk");
+      }catch (IllegalArgumentException e) {
+         assertEquals("unrecognized rule operator: odk", e.getMessage());
+      }
+   }
+
+   @Test
    public void testGetJsonRepresentation(){
       String ruleId = generateId();
-      ColorRule cr = new ColorRule(ruleId, "myElement1", ColorRule.RuleType.NO_OP, "-1", Color.YELLOW, Color.BLACK);
+      ColorRule cr = new ColorRule(ruleId, MY_ELEMENT, ColorRule.RuleType.NO_OP, "-1", Color.YELLOW, Color.BLACK);
       TreeMap<String,Object> expected = new TreeMap<>();
       expected.put("mValue", "-1");
-      expected.put("mElementKey", "myElement1");
+      expected.put("mElementKey", MY_ELEMENT);
       expected.put("mOperator", "NO_OP");
       expected.put("mId", ruleId);
       expected.put("mForeground", Color.YELLOW);
@@ -128,51 +155,62 @@ public class ColorRuleTest {
 
    @Test
    public void testToString() {
-      ColorRule cr = new ColorRule("uuid13", "myElement", ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
+      ColorRule cr = new ColorRule("uuid13", MY_ELEMENT, ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
       String expected = "[id=uuid13, elementKey=myElement, operator=EQUAL, value=1, background=-1, foreground=-16776961]";
 
       assertEquals(expected, cr.toString());
    }
-
-   private static final String APP_NAME = "colorRuleTest";
-   private static final String TABLE_ID_1 = "myTableId_1";
-   private static final String COLOR_COL = "Color_Col";
-
+   
    @Test
    public void testCheckMatch() {
-      ColorRule cr1 = new ColorRule(generateId(), "myElement1",  ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
-      ColorRule cr2 = new ColorRule(generateId(), "myElement2",  ColorRule.RuleType.LESS_THAN, "2", Color.BLUE, Color.WHITE);
-      ColorRule cr3 = new ColorRule(generateId(), "myElement3",  ColorRule.RuleType.LESS_THAN_OR_EQUAL, "3", Color.BLUE, Color.WHITE);
-      ColorRule cr4 = new ColorRule(generateId(), "myElement4",  ColorRule.RuleType.GREATER_THAN, "4", Color.BLUE, Color.WHITE);
-      ColorRule cr5 = new ColorRule(generateId(), "myElement5",  ColorRule.RuleType.GREATER_THAN_OR_EQUAL, "5", Color.BLUE, Color.WHITE);
+      //Create test values
+      ColorRule cr1 = new ColorRule(generateId(), MY_ELEMENT_1,  ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
+      ColorRule cr2 = new ColorRule(generateId(), MY_ELEMENT_2,  ColorRule.RuleType.LESS_THAN, "2", Color.BLUE, Color.WHITE);
+      ColorRule cr3 = new ColorRule(generateId(), MY_ELEMENT_3,  ColorRule.RuleType.LESS_THAN_OR_EQUAL, "3", Color.BLUE, Color.WHITE);
+      ColorRule cr4 = new ColorRule(generateId(), MY_ELEMENT_4,  ColorRule.RuleType.GREATER_THAN, "4", Color.BLUE, Color.WHITE);
+      ColorRule cr5 = new ColorRule(generateId(), MY_ELEMENT_5,  ColorRule.RuleType.GREATER_THAN_OR_EQUAL, "5", Color.BLUE, Color.WHITE);
+      ColorRule cr6 = new ColorRule(generateId(), MY_ELEMENT_6,  ColorRule.RuleType.GREATER_THAN_OR_EQUAL, "5", Color.BLUE, Color.WHITE);
+      ColorRule cr = new ColorRule(generateId(), MY_ELEMENT,  ColorRule.RuleType.NO_OP, "5", Color.BLUE, Color.WHITE);
 
+      //Setup Color table
+      String[] primaryKeys = {cr1.getRuleId(), cr2.getRuleId(), cr3.getRuleId(), cr4.getRuleId(), cr5.getRuleId()};
+      String[] elementKeys = {MY_ELEMENT_1, MY_ELEMENT_2, MY_ELEMENT_3, MY_ELEMENT_4, MY_ELEMENT_5, MY_ELEMENT, MY_ELEMENT_6};
+      BaseTable table = new BaseTable(primaryKeys, elementKeys, generateElementKeyToIndex(elementKeys), 5);
+      //Define the table's column
       List<Column> columns = new ArrayList<>();
       columns.add(new Column(COLOR_COL, COLOR_COL, ElementDataType.integer.name(), null));
       OrderedColumns orderedColumns = new OrderedColumns(APP_NAME, TABLE_ID_1, columns);
-      String[] primaryKeys = {cr1.getRuleId(), cr2.getRuleId(), cr3.getRuleId(), cr4.getRuleId(), cr5.getRuleId()};
-      String[] elementKeys = {"myElement1", "myElement2", "myElement3", "myElement4", "myElement5", "myElement"};
-      BaseTable table = new BaseTable(primaryKeys, elementKeys, generateElementKeyToIndex(elementKeys), 5);
+      //Define the table's rows
       Row row;
       TypedRow rowToMatch;
-      row= new Row(new String[]{"1","1","3","5","5","0"}, table);
+      row= new Row(new String[]{"1","1","3","5","5",null}, table);
       table.addRow(row);
       rowToMatch = new TypedRow(table.getRowAtIndex(0),orderedColumns);
-
+      //Check that all RuleTypes work with integer or number type
       assertTrue(cr1.checkMatch(ElementDataType.integer, rowToMatch));
       assertTrue(cr2.checkMatch(ElementDataType.integer, rowToMatch));
       assertTrue(cr3.checkMatch(ElementDataType.integer, rowToMatch));
       assertTrue(cr4.checkMatch(ElementDataType.integer, rowToMatch));
-      assertTrue(cr5.checkMatch(ElementDataType.integer, rowToMatch));
+      assertTrue(cr5.checkMatch(ElementDataType.number, rowToMatch));
+      assertFalse(cr.checkMatch(ElementDataType.integer, rowToMatch));
 
-      row= new Row(new String[]{"0","2","4","4","3"}, table);
+      row= new Row(new String[]{"","false","[44,67]","4","3","5","odk"}, table);
       table.addRow(row);
       rowToMatch = new TypedRow(table.getRowAtIndex(1),orderedColumns);
-
-      assertFalse(cr1.checkMatch(ElementDataType.integer, rowToMatch));
-      assertFalse(cr2.checkMatch(ElementDataType.integer, rowToMatch));
-      assertFalse(cr3.checkMatch(ElementDataType.integer, rowToMatch));
-      assertFalse(cr4.checkMatch(ElementDataType.integer, rowToMatch));
-      assertFalse(cr5.checkMatch(ElementDataType.integer, rowToMatch));
+      //Check that RuleTypes work with non-numeric types
+      assertFalse(cr1.checkMatch(ElementDataType.string, rowToMatch));
+      cr2.setVal("true");
+      assertTrue(cr2.checkMatch(ElementDataType.bool, rowToMatch));
+      cr3.setVal("[2,3,4]");
+      assertFalse(cr3.checkMatch(ElementDataType.array, rowToMatch));
+      assertFalse(cr4.checkMatch(ElementDataType.string, rowToMatch));
+      assertFalse(cr5.checkMatch(ElementDataType.string, rowToMatch));
+     try {
+        cr.checkMatch(ElementDataType.integer, rowToMatch);
+     }catch (IllegalArgumentException e) {
+        assertEquals("unrecognized op passed to checkMatch: NO_OP", e.getMessage());
+     }
+      cr6.checkMatch(ElementDataType.integer, rowToMatch);
    }
 
    private String generateId(){
@@ -186,4 +224,14 @@ public class ColorRuleTest {
       }
       return elementKeyToIndex;
    }
+   private static final String APP_NAME = "colorRuleTest";
+   private static final String TABLE_ID_1 = "myTableId_1";
+   private static final String COLOR_COL = "Color_Col";
+   private static final String MY_ELEMENT = "myElement";
+   private static final String MY_ELEMENT_1 = "myElement1";
+   private static final String MY_ELEMENT_2 = "myElement2";
+   private static final String MY_ELEMENT_3 = "myElement3";
+   private static final String MY_ELEMENT_4 = "myElement4";
+   private static final String MY_ELEMENT_5 = "myElement5";
+   private static final String MY_ELEMENT_6 = "myElement6";
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -96,6 +96,7 @@ public class ColorRuleTest {
 
       Assert.assertTrue(cr1.equalsWithoutId(cr2));
    }
+
    //Test to show if the returned Json representation for ColorRule is correct
    @Test
    public void testGetJsonRepresentation(){
@@ -111,4 +112,13 @@ public class ColorRuleTest {
 
       assertEquals(expected, cr.getJsonRepresentation());
    }
+
+   @Test
+   public void testToString() {
+      ColorRule cr = new ColorRule("uuid13", "myElement", ColorRule.RuleType.EQUAL, "1", Color.BLUE, Color.WHITE);
+      String expected = "[id=uuid13, elementKey=myElement, operator=EQUAL, value=1, background=-1, foreground=-16776961]";
+
+      assertEquals(expected, cr.toString());
+   }
+
 }


### PR DESCRIPTION
### What's in this PR?
This PR addresses issue [#507](https://github.com/odk-x/tool-suite-X/issues/507) to increase test coverage by adding unit tests for the methods in ColorRule Class under [DataClass](https://output.circle-artifacts.com/output/job/4b08f2c0-2184-4520-9502-71b52a4170a2/artifacts/0/androidlibrary_lib/build/reports/coverage/test/snapshot/debug/org.opendatakit.data/index.html)
 The test description and results are given below.

####  Added Tests

- `givenColorRule_whenJsonRepresentationRequested_thenReturnMapOfAttributesToValues`  The test sets the expected json map and asserts that the output of getJsonRepresentation() is the same as expected.
- `givenColorRule_whenStringRequested_thenReturnStringOfAttributesToValuesAssignmentSeparatedByComma:` The test creates ColorRule, sets the expected string and asserts true for the toString() result.
- `givenValidColorRuleInTableRow_whenRowSearched_thenReturnTrue:` This test cover checking if the entry of a row matches the ColorRule based on the ruleType.
- `givenValidColorRuleInTableRow_whenRowSearched_andOperatorIsNoOp_orDiffElementTypeSpec_thenReturnFalse` This test covers cases where a false is expected from match result such as when the Element type is different or when the operator I not a valid operator.
- `givenValidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType:` Confirms that the RuleType returned from a String matches the correct ruleType.
- `givenInvalidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType` confirms an exception is thrown when an invalid string is supplied.
- `givenColorRuleType_whenGetSymbolIsCalled_thenReturnCorrectSymbol:` Confirms that the symbol returned is correct.
- `givenColorRule_whenJsonRepresentationRequested_thenReturnMapOfAttributesToValues' - This test confirms that the map of values 

#### Result

> ![image](https://github.com/user-attachments/assets/02b256d4-4efe-4d8c-b268-6376e1d5d942)


This test has improved class coverage and method coverage to 100% and line coverage to 97% for the data class as shown below.

> #### Before
> ![image](https://github.com/user-attachments/assets/8dc254d7-ab61-4562-989b-84943dc62ff1)
> #### After 
> ![image](https://github.com/user-attachments/assets/67900c80-163f-4bf3-9c8c-b6ba9d8791d9)


### What is left to be done in the addressed issue?
Logging Class
DateUtil Class

### What problems did you encounter?
In creating the test cases, I ran into the `Error: "Method ... not mocked"` for the alpha and rgb color formats for Color in android.graphics.
