### PR TITLE
Added unit tests for DateUtils class

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -33,16 +33,14 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
-  private DateUtils util;
+  private static DateUtils util;
 
   @BeforeClass
   public static void oneTimeSetUp() {
     StaticStateManipulator.get().reset();
     WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
-  }
 
-  @Before
-  public void setup() {
+    // Set up TimeZone and DateUtils
     TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
     util = new DateUtils(Locale.US, tz);
   }
@@ -56,7 +54,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testNowInput() {
+  public void validifyDateValue_withNowInput_returnsFormattedCurrentDate() {
     String value = util.validifyDateValue("now");
     assertNotNull(value);
 
@@ -69,7 +67,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testTimeAddition() {
+  public void validifyDateValue_withfutureTimeInput_returnsTimeInTheFuture() {
     String value = util.validifyDateValue("now + 10m");
     assertNotNull(value);
 
@@ -80,7 +78,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testTimeSubtraction() {
+  public void validifyDateValue_withPastTimeInput_returnsTimeInThePast() {
     String value = util.validifyDateValue("now - 3h");
     assertNotNull(value);
 
@@ -91,13 +89,13 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testInvalidTime() {
+  public void validifyDateValue_withUnsupportedUnitInput_returnsNull() {
     String value = util.validifyDateValue("now - 3y");
     assertNull(value);
   }
 
   @Test
-  public void testInvalidTimeFormat() {
+  public void validifyDateValue_withInvalidTimeFormat_returnsNull() {
     String value = util.validifyDateValue("invalid-date");
     assertNull(value);
   }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -15,6 +15,7 @@
 package org.opendatakit.utilities;
 
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
+  private DateUtils util;
 
   @BeforeClass
   public static void oneTimeSetUp() {
@@ -39,11 +41,14 @@ public class DateUtilsTest {
     WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
   }
 
+  @Before
+  public void setup() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    util = new DateUtils(Locale.US, tz);
+  }
+
   @Test
   public void testDateInterpretation() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-    
     String value = util.validifyDateValue("3/4/2015");
     
     String expected = "2015-03-04T";
@@ -52,9 +57,6 @@ public class DateUtilsTest {
 
   @Test
   public void testNowInput() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now");
     assertNotNull(value);
 
@@ -68,9 +70,6 @@ public class DateUtilsTest {
 
   @Test
   public void testTimeAddition() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now + 10m");
     assertNotNull(value);
 
@@ -82,9 +81,6 @@ public class DateUtilsTest {
 
   @Test
   public void testTimeSubtraction() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now - 3h");
     assertNotNull(value);
 
@@ -96,18 +92,12 @@ public class DateUtilsTest {
 
   @Test
   public void testInvalidTime() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now - 3y");
     assertNull(value);
   }
 
   @Test
   public void testInvalidTimeFormat() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("invalid-date");
     assertNull(value);
   }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -46,7 +46,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testDateInterpretation() {
+  public void validifyDateValue_withDateInput_returnsFormattedDate() {
     String value = util.validifyDateValue("3/4/2015");
     
     String expected = "2015-03-04T";

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -14,6 +14,7 @@
 
 package org.opendatakit.utilities;
 
+import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +26,9 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
@@ -44,6 +48,68 @@ public class DateUtilsTest {
     
     String expected = "2015-03-04T";
     assertEquals(expected, value.substring(0,expected.length()));
+  }
+
+  @Test
+  public void testNowInput() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now");
+    assertNotNull(value);
+
+    DateTime now = new DateTime();
+    String expectedFormattedDate = util.formatDateTimeForDb(now);
+
+    // This is to take the slight delay when checking for output into consideration
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testTimeAddition() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now + 10m");
+    assertNotNull(value);
+
+    DateTime nowPlus10Minutes = new DateTime().plusMinutes(10);
+    String expectedFormattedDate = util.formatDateTimeForDb(nowPlus10Minutes);
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testTimeSubtraction() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now - 3h");
+    assertNotNull(value);
+
+    DateTime nowMinus3Hours = new DateTime().minusHours(3);
+    String expectedFormattedDate = util.formatDateTimeForDb(nowMinus3Hours);
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testInvalidTime() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now - 3y");
+    assertNull(value);
+  }
+
+  @Test
+  public void testInvalidTimeFormat() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("invalid-date");
+    assertNull(value);
   }
 
 }


### PR DESCRIPTION
This PR addresses issues [#507](https://github.com/odk-x/tool-suite-X/issues/507) and [#510](https://github.com/odk-x/tool-suite-X/issues/510) by improving the test coverage of the DateUtils class

## What was done
Added tests for the `tryParseDuration` method, testing for different valid and invalid duration inputs and making sure each input string returns the correct integer according to the respective unit.

Note: As a result of the slight delay in milliseconds in returning the output, the tests make assertions omitting the milliseconds

<img width="1400" alt="Screenshot 2024-10-14 at 15 57 38" src="https://github.com/user-attachments/assets/74017c80-6913-457b-8b4d-c901c0f5b65b">
