### PR TITLE
Add-OrderedColumn-test

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/data/OrderedColumnsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/data/OrderedColumnsTest.java
@@ -1,0 +1,4 @@
+package org.opendatakit.database.data;
+
+public class OrderedColumnsTest {
+}

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/data/OrderedColumnsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/data/OrderedColumnsTest.java
@@ -1,4 +1,122 @@
 package org.opendatakit.database.data;
+import android.os.Parcel;
+import org.junit.Before;
+import org.junit.Test;
+import org.opendatakit.aggregate.odktables.rest.ElementDataType;
+import org.opendatakit.aggregate.odktables.rest.ElementType;
+import org.opendatakit.aggregate.odktables.rest.entity.Column;
+import org.opendatakit.database.data.ColumnDefinition;
+import org.opendatakit.database.data.OrderedColumns;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import static org.junit.Assert.*;
 
 public class OrderedColumnsTest {
+   private String appName;
+    private String tableId;
+    private List<Column> testColumns;
+
+    @Before
+    public void setUp() {
+        appName = "testApp";
+        tableId = "testTable";
+
+        testColumns = new ArrayList<>();
+        testColumns.add(new Column("elementKey1", "elementName1", "elementType1", "[]")); // Use an empty JSON array for no children
+        testColumns.add(new Column("elementKey2", "elementName2", "elementType2", "[]")); // Modify child keys as per actual validation rules
+    }
+
+
+    @Test
+    public void ConstructorWithValidList() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        assertNotNull(orderedColumns);
+        assertEquals(appName, orderedColumns.getAppName());
+        assertEquals(tableId, orderedColumns.getTableId());
+        assertNotNull(orderedColumns.getColumnDefinitions());
+    }
+
+    @Test
+    public void WriteToParcel() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        Parcel parcel = Parcel.obtain();
+        orderedColumns.writeToParcel(parcel, 0);
+
+        parcel.setDataPosition(0);
+
+        OrderedColumns createdFromParcel = OrderedColumns.CREATOR.createFromParcel(parcel);
+        assertEquals(appName, createdFromParcel.getAppName());
+        assertEquals(tableId, createdFromParcel.getTableId());
+
+        assertEquals(testColumns.size(), createdFromParcel.getColumns().size());
+
+        parcel.recycle();
+    }
+
+    @Test
+    public void testFind() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+
+        ColumnDefinition foundColumn = orderedColumns.find("elementKey1");
+        assertNotNull(foundColumn);
+        assertEquals("elementKey1", foundColumn.getElementKey());
+
+        try {
+            orderedColumns.find("nonExistentKey");
+            fail("Expected an IllegalArgumentException to be thrown");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+    @Test
+    public void GetRetentionColumnNames() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        ArrayList<String> retentionColumns = orderedColumns.getRetentionColumnNames();
+        assertNotNull(retentionColumns);
+        assertTrue(retentionColumns.size() > 0);  // At least one retention column should exist
+    }
+
+    @Test
+    public void GraphViewIsPossible() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        boolean graphView = orderedColumns.graphViewIsPossible();
+        assertFalse(graphView);
+    }
+
+    @Test
+    public void MapViewIsPossible() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        boolean mapView = orderedColumns.mapViewIsPossible();
+        assertFalse(mapView);
+    }
+
+    @Test
+    public void GetGeopointColumnDefinitions() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        ArrayList<ColumnDefinition> geopointColumns = orderedColumns.getGeopointColumnDefinitions();
+        assertNotNull(geopointColumns);
+        assertTrue(geopointColumns.isEmpty());
+    }
+
+    @Test
+    public void ParcelCreator() {
+        OrderedColumns[] orderedColumnsArray = OrderedColumns.CREATOR.newArray(2);
+        assertEquals(2, orderedColumnsArray.length);
+    }
+
+    @Test
+    public void GetDataModel() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        TreeMap<String, Object> dataModel = orderedColumns.getDataModel();
+        assertNotNull(dataModel);
+        assertTrue(dataModel.size() > 0);
+    }
+
+    @Test
+    public void GetExtendedDataModel() {
+        OrderedColumns orderedColumns = new OrderedColumns(appName, tableId, testColumns);
+        TreeMap<String, Object> extendedDataModel = orderedColumns.getExtendedDataModel();
+        assertNotNull(extendedDataModel);
+        assertTrue(extendedDataModel.size() > 0);
+    }
 }


### PR DESCRIPTION
### PR: Unit Tests for  OrderedColumns 

This PR introduces unit tests for the `ColumnList` and `OrderedColumns` classes from the `org.opendatakit.database.data` package. These classes are responsible for managing lists of `Column` objects .

#### Key Highlights:  
- **`OrderedColumns` Tests:**
  - Verify initialization with valid column data and ensure the correct retention of app name, table ID, and column definitions.
  - Test `writeToParcel` and `readFromParcel` methods for `OrderedColumns`.
  - Test the `find()` method for retrieving specific `ColumnDefinition` instances and handling non-existent keys.
  - Check various methods like `getRetentionColumnNames`, `graphViewIsPossible`, `mapViewIsPossible`, and `getGeopointColumnDefinitions`.
  - Validate the creation of extended data models from `OrderedColumns`.
![Screenshot 1403-07-30 at 15 23 50](https://github.com/user-attachments/assets/7506805d-bf05-4071-ac0c-bcf1fb9a9ae9)
https://github.com/odk-x/tool-suite-X/issues/513
https://github.com/odk-x/tool-suite-X/issues/507