### PR TITLE
Add-baseTable-Test

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/BaseTableTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/BaseTableTest.java
@@ -1,0 +1,59 @@
+package org.opendatakit.database;
+
+import android.os.Parcel;
+import org.junit.Before;
+import org.junit.Test;
+import org.opendatakit.database.data.BaseTable;
+import org.opendatakit.database.queries.ResumableQuery;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class BaseTableTest {
+
+    private BaseTable baseTable;
+
+    @Before
+    public void setUp() {
+        String[] primaryKey = {"id"};
+        String[] elementKeyForIndex = {"column1", "column2"};
+        Map<String, Integer> elementKeyToIndex = new HashMap<>();
+        elementKeyToIndex.put("column1", 0);
+        elementKeyToIndex.put("column2", 1);
+
+        ResumableQuery query = null;
+
+        baseTable = new BaseTable(query, elementKeyForIndex, elementKeyToIndex, primaryKey, 0);
+    }
+
+    @Test
+    public void testGetWidth() {
+
+        int width = baseTable.getWidth();
+
+        assertEquals(2, width);
+    }
+
+    @Test
+    public void testGetPrimaryKey() {
+        String[] primaryKey = baseTable.getPrimaryKey();
+
+        assertArrayEquals(new String[]{"id"}, primaryKey);
+    }
+
+    @Test
+    public void testParcelable() {
+        Parcel parcel = Parcel.obtain();
+        baseTable.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        BaseTable createdFromParcel = BaseTable.CREATOR.createFromParcel(parcel);
+
+        assertNotNull(createdFromParcel);
+        assertArrayEquals(baseTable.getPrimaryKey(), createdFromParcel.getPrimaryKey());
+        assertEquals(baseTable.getWidth(), createdFromParcel.getWidth());
+
+        parcel.recycle();
+    }
+}


### PR DESCRIPTION
****Description:****

- This unit test suite for the BaseTable class in the org.opendatakit.database.data package is designed to validate the core functionality of the class. The tests will focus on key methods, ensuring that they behave as expected under various scenarios. Specifically, the tests will verify:

- The ability to add rows to the table and update the row count correctly.

- Accurate retrieval of rows by index, ensuring the correct row is returned.

-  The width of the table matches the number of columns defined.

- The correct handling of primary keys and their retrieval.
#[513](https://github.com/odk-x/tool-suite-X/issues/513)
<img width="604" alt="Screenshot 1403-07-30 at 11 55 57" src="https://github.com/user-attachments/assets/09cb28aa-0ec3-41b4-91cf-e0366dfa013a">

