### PR TITLE
Added tests for Queryutil class

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
@@ -1,0 +1,15 @@
+package org.opendatakit.database.utilities;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class QueryUtilTest {
+
+    @Test
+    public void buildSqlStatement_withBasicInput_returnBasicOutput() {
+        String tableId = "test_table";
+        String sql = QueryUtil.buildSqlStatement(tableId, null, null, null, null, null);
+        assertEquals("SELECT * FROM \"test_table\" ", sql);
+    }
+}

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
@@ -12,4 +12,19 @@ public class QueryUtilTest {
         String sql = QueryUtil.buildSqlStatement(tableId, null, null, null, null, null);
         assertEquals("SELECT * FROM \"test_table\" ", sql);
     }
+
+    @Test
+    public void buildSqlStatement_withWhereClause_returnWhereStatement() {
+        String whereClause = "name = 'Bob'";
+        String sql = QueryUtil.buildSqlStatement("test_table", whereClause, null, null, null, null);
+        assertEquals("SELECT * FROM \"test_table\" WHERE name = 'Bob'", sql);
+    }
+
+    @Test
+    public void buildSqlStatement_withHavingClause_returnHavingStatement() {
+        String[] groupBy = { "class" };
+        String havingClause = "COUNT(class) > 4";
+        String sql = QueryUtil.buildSqlStatement("test_table", null, groupBy, havingClause, null, null);
+        assertEquals("SELECT * FROM \"test_table\" GROUP BY class HAVING COUNT(class) > 4", sql);
+    }
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/QueryUtilTest.java
@@ -17,7 +17,7 @@ public class QueryUtilTest {
     public void buildSqlStatement_withWhereClause_returnWhereStatement() {
         String whereClause = "name = 'Bob'";
         String sql = QueryUtil.buildSqlStatement("test_table", whereClause, null, null, null, null);
-        assertEquals("SELECT * FROM \"test_table\" WHERE name = 'Bob'", sql);
+        assertEquals("SELECT * FROM \"test_table\"  WHERE name = 'Bob'", sql);
     }
 
     @Test
@@ -25,6 +25,31 @@ public class QueryUtilTest {
         String[] groupBy = { "class" };
         String havingClause = "COUNT(class) > 4";
         String sql = QueryUtil.buildSqlStatement("test_table", null, groupBy, havingClause, null, null);
-        assertEquals("SELECT * FROM \"test_table\" GROUP BY class HAVING COUNT(class) > 4", sql);
+        assertEquals("SELECT * FROM \"test_table\"  GROUP BY class HAVING COUNT(class) > 4", sql);
+    }
+
+    @Test
+    public void buildSqlStatement_withOrderBy_returnOrderByStatement() {
+        String[] orderBy = { "updated_at" };
+        String sql = QueryUtil.buildSqlStatement("test_table", null, null, null, orderBy, null);
+        assertEquals("SELECT * FROM \"test_table\"  ORDER BY updated_at ASC", sql);
+    }
+
+    @Test
+    public void buildSqlStatement_withOrderByDirection_returnOrderByDirectionStatement() {
+        String[] orderBy = { "created_at" };
+        String[] orderByDirection = { "DESC" };
+        String sql = QueryUtil.buildSqlStatement("test_table", null, null, null, orderBy, orderByDirection);
+        assertEquals("SELECT * FROM \"test_table\"  ORDER BY created_at DESC", sql);
+    }
+
+    @Test
+    public void buildSqlStatement_withAllClauses_returnComplexStatement() {
+        String[] groupBy = { "class" };
+        String[] orderBy = { "created_at", "name" };
+        String[] orderByDirection = { "DESC", "ASC" };
+        String sql = QueryUtil.buildSqlStatement("test_table", "name = 'Bob'", groupBy, "COUNT(class) > 4", orderBy, orderByDirection);
+        assertEquals("SELECT * FROM \"test_table\"  WHERE name = 'Bob' GROUP BY class HAVING COUNT(class) > 4 ORDER BY created_at DESC, name ASC", sql);
+
     }
 }


### PR DESCRIPTION
This PR addresses [#507](https://github.com/odk-x/tool-suite-X/issues/507) and [#517](https://github.com/odk-x/tool-suite-X/issues/517) by improving the test coverage of the QueryUtil class by 50%

## What was done
Added tests for the `buildSqlStatement ` method, testing for different combinations of input parameters and making the correct SQL string is returned for each input.

The test cases are outlined as follows:

**Basic Case**: Verifies the sql output when only `tableId` is specified.

**Where Clause**: Tests when a `where` clause is provided.

**Group By**: Tests with a groupBy parameter to ensure grouping is handled.

**Having Clause**: Tests a `having` clause with `groupBy`.

**Order By**: Tests with `orderByElementKey` to verify the ordering defaults to ASC.

**Order By with Direction**: Tests with `orderByDirection` to verify it applies the correct ordering.

**Complex Case**: Tests with all parameters combined to validate the full SQL structure.

<img width="1397" alt="Screenshot 2024-10-26 at 21 11 21" src="https://github.com/user-attachments/assets/6e827e54-1684-403c-aa90-433cddef9bf9">
