### PR TITLE
Add-Service-Tests

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/application/Services.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/application/Services.java
@@ -1,0 +1,74 @@
+package org.opendatakit.application;
+
+import android.content.Context;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.junit.FixMethodOrder;
+import org.opendatakit.services.R;
+import org.opendatakit.services.application.Services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ServicesTest {
+
+    private Services services;
+
+    @Rule
+    public final ODKServiceTestRule mServiceRule = new ODKServiceTestRule();
+
+    @Before
+    public void setUp() throws Exception {
+        services = new Services();
+        services.onCreate();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void OnCreate_initializesServices() {
+        assertNotNull(services);
+    }
+
+    @Test
+    public void GetApkDisplayNameResourceId() {
+        int apkDisplayNameResourceId = services.getApkDisplayNameResourceId();
+        assertEquals(R.string.app_name, apkDisplayNameResourceId);
+    }
+
+    @Test
+    public void SingletonInstanceInitialization() {
+        Context singleton = Services._please_dont_use_getInstance();
+        assertNotNull(singleton);
+    }
+
+    public class ODKServiceTestRule implements org.junit.rules.TestRule {
+        @Override
+        public org.junit.runners.model.Statement apply(final org.junit.runners.model.Statement base,
+                                                       final org.junit.runner.Description description) {
+            return new org.junit.runners.model.Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        beforeService();
+                        base.evaluate();
+                    } finally {
+                        afterService();
+                    }
+                }
+            };
+        }
+
+        protected void beforeService() {
+        }
+
+        protected void afterService() {
+        }
+    }
+}


### PR DESCRIPTION
The `ServicesTest` class verifies the functionality of the `Services` class, responsible for initializing core components within the ODK application. Key tests include:

- **Initialization on Creation**: Confirms that the `Services` class initializes as expected upon creation.
- **APK Display Name Retrieval**: Verifies that the correct application name resource ID is returned using `getApkDisplayNameResourceId()`.
- **Singleton Access**: Ensures the singleton instance `_please_dont_use_getInstance()` provides a non-null `Context`, indicating the singleton is set up correctly.

The custom `ODKServiceTestRule` manages setup and teardown operations before and after each test, maintaining a clean testing environment for service-level tests. This suite provides essential coverage for service initialization and singleton pattern checks.
![376005768-b815c0cc-b4e2-4964-ad84-cadaffa49368](https://github.com/user-attachments/assets/5822bc2b-644b-441b-b461-9b7548674ea8)
 Fixing https://github.com/odk-x/tool-suite-X/issues/505
@wbrunette @Stryker101 @r0ssing