### PR TITLE
Dateutil unit test

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -48,6 +48,25 @@ import java.util.UUID;
 
 @RunWith(JUnit4.class)
 public class ColorRuleTest {
+
+   //Constants
+   private static final String APP_NAME = "colorRuleTest";
+   private static final String TABLE_ID_1 = "myTableId_1";
+   private static final String COLOR_COL = "Color_Col";
+   private static final String MY_ELEMENT = "myElement";
+   private static final String MY_ELEMENT_1 = "myElement1";
+   private static final String MY_ELEMENT_2 = "myElement2";
+   private static final String MY_ELEMENT_3 = "myElement3";
+   private static final String MY_ELEMENT_4 = "myElement4";
+   private static final String MY_ELEMENT_5 = "myElement5";
+   private static final String MY_ELEMENT_6 = "myElement6";
+   private static final String EQUAL_SYMBOL = "=";
+   private static final String LESS_THAN_SYMBOL = "<";
+   private static final String LESS_THAN_OR_EQUAL_SYMBOL = "<=";
+   private static final String GREATER_THAN_OR_EQUAL_SYMBOL = ">=";
+   private static final String GREATER_THAN_SYMBOL = ">";
+   //
+
    String ruleId = UUID.randomUUID().toString();
    ColorRule cr;
 
@@ -65,11 +84,12 @@ public class ColorRuleTest {
    public void tearDownColorRule(){
       cr = null;
    }
+   
    @Test
    public void testColorRule() {
-      ColorRule cr1 = new ColorRule("myElement", ColorRule.RuleType.EQUAL, "5", Color.BLUE, Color
+      ColorRule cr1 = new ColorRule(MY_ELEMENT, ColorRule.RuleType.EQUAL, "5", Color.BLUE, Color
           .WHITE);
-      ColorRule cr2 = new ColorRule("myElement", ColorRule.RuleType.EQUAL, "5", Color.BLUE, Color
+      ColorRule cr2 = new ColorRule(MY_ELEMENT, ColorRule.RuleType.EQUAL, "5", Color.BLUE, Color
           .WHITE);
 
       Assert.assertTrue(cr1.equalsWithoutId(cr2));
@@ -78,7 +98,7 @@ public class ColorRuleTest {
       Assert.assertEquals(Color.WHITE, cr1.getBackground());
       Assert.assertEquals(Color.BLUE, cr1.getForeground());
       Assert.assertEquals(ColorRule.RuleType.EQUAL, cr1.getOperator());
-      Assert.assertEquals("myElement", cr1.getColumnElementKey());
+      Assert.assertEquals(MY_ELEMENT, cr1.getColumnElementKey());
       Assert.assertEquals("5", cr1.getVal());
 
       String crs1 = cr1.toString();
@@ -124,13 +144,6 @@ public class ColorRuleTest {
       Assert.assertTrue(cr1.equalsWithoutId(cr2));
    }
 
-   /**getSymbol() test.
-    * Acceptance:
-    * Given: color rule with a valid rule type
-    * When: asked for the rule symbol
-    * Then: Return the correct string value
-    * [RULE_TYPE: EXPECTED_SYMBOL] = {EQUAL: =, LESS_THAN: <, LESS_THAN_OR_EQUAL: <=, GREATER_THAN_OR_EQUAL: >=, GREATER_THAN: >}
-   */
    @Test
    public void givenColorRuleType_whenGetSymbolIsCalled_thenReturnCorrectSymbol() {
       assertEquals(EQUAL_SYMBOL, cr.getOperator().getSymbol());
@@ -148,13 +161,6 @@ public class ColorRuleTest {
       assertEquals(GREATER_THAN_OR_EQUAL_SYMBOL, cr.getOperator().getSymbol());
    }
 
-   /**getValues() test.
-    * Acceptance:
-    * Given: a list of strings
-    * When: the list is accessed
-    * Then: the list has the rule type symbols in the correct order
-    * [STRING_VALUE: EXPECTED_RULE_TYPE] = {=: EQUAL, <: LESS_THAN, <=: LESS_THAN_OR_EQUAL, >=: GREATER_THAN_OR_EQUAL,  >: GREATER_THAN}
-    */
    @Test
    public void givenCharSequenceOfValues_whenSequenceIsAccessed_thenReturnRuleTypeSymbolInCorrectOrder() {
       CharSequence[] ruleTypeStrings = getValues();
@@ -164,13 +170,7 @@ public class ColorRuleTest {
       assertEquals(GREATER_THAN_OR_EQUAL_SYMBOL, ruleTypeStrings[3].toString());
       assertEquals(GREATER_THAN_SYMBOL, ruleTypeStrings[4].toString());
    }
-      /**getEnumFromString() test.
-       * Acceptance:
-       * Given: a string value AND string is a valid rule symbol
-       * When: corresponding rule type is fetched
-       * Then: return the correct rule type
-       * [STRING_VALUE: EXPECTED_RULE_TYPE] = {=: EQUAL, <: LESS_THAN, <=: LESS_THAN_OR_EQUAL, >=: GREATER_THAN_OR_EQUAL,  >: GREATER_THAN}
-       */
+
    @Test
    public void givenValidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType() {
       assertEquals(ColorRule.RuleType.LESS_THAN, ColorRule.RuleType.getEnumFromString(LESS_THAN_SYMBOL));
@@ -180,24 +180,12 @@ public class ColorRuleTest {
       assertEquals(ColorRule.RuleType.GREATER_THAN, ColorRule.RuleType.getEnumFromString(GREATER_THAN_SYMBOL));
       assertEquals(ColorRule.RuleType.NO_OP, ColorRule.RuleType.getEnumFromString(""));
    }
-   /**getEnumFromString() test.
-       * Acceptance:
-       * Given: a string value AND string is not a valid rule symbol
-       * When: corresponding rule type is fetched
-       * Then: throw an IllegalArgumentException with the correct error message
-    **/
+
    @Test
    public void givenInvalidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType() {
       assertThrows(IllegalArgumentException.class, () -> ColorRule.RuleType.getEnumFromString("odk"));
    }
 
-   //Test to show if the returned Json representation for ColorRule is correct
-   /**getJsonRepresentation() test.
-    * Acceptance:
-    * Given: a colorRule
-    * When: asked for the json representation
-    * Then: return a map of the color rule attributes to their corresponding value
-    **/
    @Test
    public void givenColorRule_whenJsonRepresentationRequested_thenReturnMapOfAttributesToValues(){
       TreeMap<String,Object> expected = new TreeMap<>();
@@ -210,28 +198,17 @@ public class ColorRuleTest {
       assertEquals(expected, cr.getJsonRepresentation());
    }
 
-   /**toString() test.
-    * Acceptance:
-    * Given: a colorRule
-    * When: asked for the string representation
-    * Then: return a string containing assignment of the color rule value to their corresponding
-    attributes, each separated by comma(,).
-    **/
    @Test
    public void givenColorRule_whenStringRequested_thenReturnStringOfAttributesToValuesAssignmentSeparatedByComma() {
       String expected = "[id="+ruleId+", elementKey=myElement, operator=EQUAL, value=1, background=-16777216, foreground=-256]";
       assertEquals(expected, cr.toString());
    }
 
-   /**checkMatch() test.
-    * Acceptance:
-    * Given: a colorRule that exists in a table row AND has a valid operator
-    * When: searched for with a specified element type in a table row of valid values
-    * Then: return true if match found with correct type.
-    **/
    @Test
    public void givenValidColorRuleInTableRow_whenRowSearched_thenReturnTrue() {
-      TypedRow rowToMatch = setupTableWithRowEntriesAndReturnTypedRow(new String[]{"1","1","3","5","5","false"});
+      TypedRow rowToMatch = setupTableWithRowEntriesAndReturnTypedRow(
+              new String[]{"1","1","3","5","5","false"}
+      );
       //Check that all RuleTypes work with integer or number type
       updateColorRule(MY_ELEMENT_1, "1", ColorRule.RuleType.EQUAL);
       assertTrue(cr.checkMatch(ElementDataType.integer, rowToMatch));
@@ -247,12 +224,6 @@ public class ColorRuleTest {
       assertTrue(cr.checkMatch(ElementDataType.bool, rowToMatch));
    }
 
-   /**checkMatch() test.
-    * Acceptance:
-    * Given: a colorRule that doesn't exist in a table row OR has an invalid operator OR has a value with unexpected type
-    * When: searched for with the expected element type in the table row
-    * Then: return false.
-    **/
    @Test
    public void givenValidColorRuleInTableRow_whenRowSearched_andOperatorIsNoOp_orDiffElementTypeSpec_thenReturnFalse() {
       TypedRow rowToMatch = setupTableWithRowEntriesAndReturnTypedRow(new String[]{"","[44,67]","4","3",null,"odk"});
@@ -278,7 +249,9 @@ public class ColorRuleTest {
    private TypedRow setupTableWithRowEntriesAndReturnTypedRow(String[] rowEntries){
       //Setup Color table
       String[] primaryKey = {"id"};
-      String[] elementKeys = {MY_ELEMENT_1, MY_ELEMENT_2, MY_ELEMENT_3, MY_ELEMENT_4, MY_ELEMENT_5, MY_ELEMENT_6};
+      String[] elementKeys = {
+              MY_ELEMENT_1, MY_ELEMENT_2, MY_ELEMENT_3, MY_ELEMENT_4, MY_ELEMENT_5, MY_ELEMENT_6
+      };
       HashMap<String, Integer> elementKeyToIndex = new HashMap<>();
       elementKeyToIndex.put(MY_ELEMENT_1,0);
       elementKeyToIndex.put(MY_ELEMENT_2,1);
@@ -303,21 +276,6 @@ public class ColorRuleTest {
       cr.setOperator(operator);
    }
 
-   private static final String APP_NAME = "colorRuleTest";
-   private static final String TABLE_ID_1 = "myTableId_1";
-   private static final String COLOR_COL = "Color_Col";
-   private static final String MY_ELEMENT = "myElement";
-   private static final String MY_ELEMENT_1 = "myElement1";
-   private static final String MY_ELEMENT_2 = "myElement2";
-   private static final String MY_ELEMENT_3 = "myElement3";
-   private static final String MY_ELEMENT_4 = "myElement4";
-   private static final String MY_ELEMENT_5 = "myElement5";
-   private static final String MY_ELEMENT_6 = "myElement6";
-   private static final String EQUAL_SYMBOL = "=";
-   private static final String LESS_THAN_SYMBOL = "<";
-   private static final String LESS_THAN_OR_EQUAL_SYMBOL = "<=";
-   private static final String GREATER_THAN_OR_EQUAL_SYMBOL = ">=";
-   private static final String GREATER_THAN_SYMBOL = ">";
    @AfterClass
    public static void clearProperties() {
       StaticStateManipulator.get().reset();

--- a/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/data/ColorRuleTest.java
@@ -144,6 +144,13 @@ public class ColorRuleTest {
       Assert.assertTrue(cr1.equalsWithoutId(cr2));
    }
 
+   /**getSymbol() test.
+    * Acceptance:
+    * Given: color rule with a valid rule type
+    * When: asked for the rule symbol
+    * Then: Return the correct string value
+    * [RULE_TYPE: EXPECTED_SYMBOL] = {EQUAL: =, LESS_THAN: <, LESS_THAN_OR_EQUAL: <=, GREATER_THAN_OR_EQUAL: >=, GREATER_THAN: >}
+   */
    @Test
    public void givenColorRuleType_whenGetSymbolIsCalled_thenReturnCorrectSymbol() {
       assertEquals(EQUAL_SYMBOL, cr.getOperator().getSymbol());
@@ -161,6 +168,13 @@ public class ColorRuleTest {
       assertEquals(GREATER_THAN_OR_EQUAL_SYMBOL, cr.getOperator().getSymbol());
    }
 
+   /**getValues() test.
+    * Acceptance:
+    * Given: a list of strings
+    * When: the list is accessed
+    * Then: the list has the rule type symbols in the correct order
+    * [STRING_VALUE: EXPECTED_RULE_TYPE] = {=: EQUAL, <: LESS_THAN, <=: LESS_THAN_OR_EQUAL, >=: GREATER_THAN_OR_EQUAL,  >: GREATER_THAN}
+    */
    @Test
    public void givenCharSequenceOfValues_whenSequenceIsAccessed_thenReturnRuleTypeSymbolInCorrectOrder() {
       CharSequence[] ruleTypeStrings = getValues();
@@ -171,6 +185,13 @@ public class ColorRuleTest {
       assertEquals(GREATER_THAN_SYMBOL, ruleTypeStrings[4].toString());
    }
 
+      /**getEnumFromString() test.
+       * Acceptance:
+       * Given: a string value AND string is a valid rule symbol
+       * When: corresponding rule type is fetched
+       * Then: return the correct rule type
+       * [STRING_VALUE: EXPECTED_RULE_TYPE] = {=: EQUAL, <: LESS_THAN, <=: LESS_THAN_OR_EQUAL, >=: GREATER_THAN_OR_EQUAL,  >: GREATER_THAN}
+       */
    @Test
    public void givenValidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType() {
       assertEquals(ColorRule.RuleType.LESS_THAN, ColorRule.RuleType.getEnumFromString(LESS_THAN_SYMBOL));
@@ -181,11 +202,24 @@ public class ColorRuleTest {
       assertEquals(ColorRule.RuleType.NO_OP, ColorRule.RuleType.getEnumFromString(""));
    }
 
+   /**getEnumFromString() test.
+       * Acceptance:
+       * Given: a string value AND string is not a valid rule symbol
+       * When: corresponding rule type is fetched
+       * Then: throw an IllegalArgumentException with the correct error message
+    **/
    @Test
    public void givenInvalidStringValue_whenGetEnumIsCalled_thenReturnCorrectRuleType() {
       assertThrows(IllegalArgumentException.class, () -> ColorRule.RuleType.getEnumFromString("odk"));
    }
 
+   //Test to show if the returned Json representation for ColorRule is correct
+   /**getJsonRepresentation() test.
+    * Acceptance:
+    * Given: a colorRule
+    * When: asked for the json representation
+    * Then: return a map of the color rule attributes to their corresponding value
+    **/
    @Test
    public void givenColorRule_whenJsonRepresentationRequested_thenReturnMapOfAttributesToValues(){
       TreeMap<String,Object> expected = new TreeMap<>();
@@ -198,12 +232,25 @@ public class ColorRuleTest {
       assertEquals(expected, cr.getJsonRepresentation());
    }
 
+   /**toString() test.
+    * Acceptance:
+    * Given: a colorRule
+    * When: asked for the string representation
+    * Then: return a string containing assignment of the color rule value to their corresponding
+    attributes, each separated by comma(,).
+    **/
    @Test
    public void givenColorRule_whenStringRequested_thenReturnStringOfAttributesToValuesAssignmentSeparatedByComma() {
       String expected = "[id="+ruleId+", elementKey=myElement, operator=EQUAL, value=1, background=-16777216, foreground=-256]";
       assertEquals(expected, cr.toString());
    }
 
+   /**checkMatch() test.
+    * Acceptance:
+    * Given: a colorRule that exists in a table row AND has a valid operator
+    * When: searched for with a specified element type in a table row of valid values
+    * Then: return true if match found with correct type.
+    **/
    @Test
    public void givenValidColorRuleInTableRow_whenRowSearched_thenReturnTrue() {
       TypedRow rowToMatch = setupTableWithRowEntriesAndReturnTypedRow(
@@ -224,6 +271,12 @@ public class ColorRuleTest {
       assertTrue(cr.checkMatch(ElementDataType.bool, rowToMatch));
    }
 
+   /**checkMatch() test.
+    * Acceptance:
+    * Given: a colorRule that doesn't exist in a table row OR has an invalid operator OR has a value with unexpected type
+    * When: searched for with the expected element type in the table row
+    * Then: return false.
+    **/
    @Test
    public void givenValidColorRuleInTableRow_whenRowSearched_andOperatorIsNoOp_orDiffElementTypeSpec_thenReturnFalse() {
       TypedRow rowToMatch = setupTableWithRowEntriesAndReturnTypedRow(new String[]{"","[44,67]","4","3",null,"odk"});

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -113,6 +113,21 @@ public class DateUtilsTest {
     assertNull(value);
   }
 
+  @Test
+  public void validifyDateValue_withTodayIntervalInput_returnsFormattedDateTimeForStartOfCurrentDay(){
+    DateUtils dateUtils = new DateUtils(NIGERIA_LOCALE, NIGERIA_TIME_ZONE);
+    String input = "today";  // Supported input format
+    DateTime expectedStart = new DateTime().withTimeAtStartOfDay();
+    String expectedOutput = getTimeString(expectedStart);
+    assertEquals(expectedOutput, dateUtils.validifyDateValue(input));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void validifyDateValue_withNullInput_returnsNull() {
+    DateUtils dateUtils = new DateUtils(Locale.ITALY, ITALY_TIME_ZONE);
+    assertNull(dateUtils.validifyDateValue(null));
+  }
+
   private String getTimeString(DateTime time){
     // convert to a nanosecond-extended iso8601-style UTC date yyyy-mm-ddTHH:MM:SS.sssssssss
     String partialPattern = "yyyy-MM-dd'T'HH:mm:ss.SSS";
@@ -127,27 +142,5 @@ public class DateUtilsTest {
   public static void oneTimeTearDown() {
     StaticStateManipulator.get().reset();
   }
-
-  @Test
-  public void testValidInstantInput(){
-    String input = "3/4/2015";
-    String expectedDateTime = "2015-03-04T00:00:00.000000000";
-    assertEquals(expectedDateTime, dateUtils.validifyDateValue(input));
-  }
-
-  @Test
-  public void testValidIntervalInput(){
-    String input = "today";  // Supported input format
-    DateTime expectedStart = new DateTime().withTimeAtStartOfDay();
-    String expectedOutput = dateUtils.formatDateTimeForDb(expectedStart);
-    assertEquals(expectedOutput, dateUtils.validifyDateValue(input));
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testNullInput() {
-    String input = null;
-    dateUtils.validifyDateValue(input);
-  }
-
 
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -26,6 +26,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
@@ -40,7 +41,6 @@ public class DateUtilsTest {
 
   private static final TimeZone NIGERIA_TIME_ZONE = TimeZone.getTimeZone("Africa/Lagos");
   private static final TimeZone CAMEROON_TIME_ZONE = TimeZone.getTimeZone("Africa/Douala");
-  private static final TimeZone LA_TIME_ZONE = TimeZone.getTimeZone("America/Los_Angeles");
   private static final TimeZone TORONTO_TIME_ZONE = TimeZone.getTimeZone("America/Toronto");
   private static final TimeZone LONDON_TIME_ZONE = TimeZone.getTimeZone("Europe/London");
   private static final TimeZone ITALY_TIME_ZONE = TimeZone.getTimeZone("Europe/Rome");
@@ -53,10 +53,11 @@ public class DateUtilsTest {
   @Test
   public void validifyDateValue_withDateInput_returnsFormattedDate() {
     // Set up TimeZone and DateUtils
-    DateUtils dateUtil = new DateUtils(NIGERIA_LOCALE, NIGERIA_TIME_ZONE);
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils dateUtil = new DateUtils(Locale.US, tz);
     String value = dateUtil.validifyDateValue("3/4/2015");
 
-    String expected = getTimeString(DateTime.parse("2015-03-04T"), NIGERIA_LOCALE, NIGERIA_TIME_ZONE) ;
+    String expected = "2015-03-04T";
     assertEquals(expected, value.substring(0,expected.length()));
   }
 
@@ -67,7 +68,7 @@ public class DateUtilsTest {
     assertNotNull(value);
 
     DateTime now = new DateTime();
-    String expectedFormattedDate = getTimeString(now, CAMEROON_LOCALE, CAMEROON_TIME_ZONE);
+    String expectedFormattedDate = getTimeString(now);
 
     // This is to take the slight delay when checking for output into consideration
     int periodIndex = expectedFormattedDate.indexOf('.');
@@ -81,19 +82,19 @@ public class DateUtilsTest {
     assertNotNull(value);
 
     DateTime nowPlus10Minutes = new DateTime().plusMinutes(10);
-    String expectedFormattedDate = getTimeString(nowPlus10Minutes, Locale.CANADA, TORONTO_TIME_ZONE);
+    String expectedFormattedDate = getTimeString(nowPlus10Minutes);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
 
   @Test
   public void validifyDateValue_withPastTimeInput_returnsTimeInThePast() {
-    DateUtils dateUtil = new DateUtils(Locale.US, LA_TIME_ZONE);
+    DateUtils dateUtil = new DateUtils(NIGERIA_LOCALE, NIGERIA_TIME_ZONE);
     String value = dateUtil.validifyDateValue("now - 3h");
     assertNotNull(value);
 
     DateTime nowMinus3Hours = new DateTime().minusHours(3);
-    String expectedFormattedDate = getTimeString(nowMinus3Hours, Locale.US, LA_TIME_ZONE);
+    String expectedFormattedDate = getTimeString(nowMinus3Hours);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
@@ -112,12 +113,12 @@ public class DateUtilsTest {
     assertNull(value);
   }
 
-  private String getTimeString(DateTime time, Locale locale, TimeZone timeZone){
+  private String getTimeString(DateTime time){
     // convert to a nanosecond-extended iso8601-style UTC date yyyy-mm-ddTHH:MM:SS.sssssssss
     String partialPattern = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    Calendar calendar = GregorianCalendar.getInstance(timeZone);
+    Calendar calendar = GregorianCalendar.getInstance(new SimpleTimeZone(0, "UT"));
 
-    SimpleDateFormat fmt = new SimpleDateFormat(partialPattern, locale);
+    SimpleDateFormat fmt = new SimpleDateFormat(partialPattern, Locale.ROOT);
     fmt.setCalendar(calendar);
     Date d = new Date(time.getMillis());
     return fmt.format(d) + "000000";

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -128,4 +128,26 @@ public class DateUtilsTest {
     StaticStateManipulator.get().reset();
   }
 
+  @Test
+  public void testValidInstantInput(){
+    String input = "3/4/2015";
+    String expectedDateTime = "2015-03-04T00:00:00.000000000";
+    assertEquals(expectedDateTime, dateUtils.validifyDateValue(input));
+  }
+
+  @Test
+  public void testValidIntervalInput(){
+    String input = "today";  // Supported input format
+    DateTime expectedStart = new DateTime().withTimeAtStartOfDay();
+    String expectedOutput = dateUtils.formatDateTimeForDb(expectedStart);
+    assertEquals(expectedOutput, dateUtils.validifyDateValue(input));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullInput() {
+    String input = null;
+    dateUtils.validifyDateValue(input);
+  }
+
+
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -15,15 +15,18 @@
 package org.opendatakit.utilities;
 
 import org.joda.time.DateTime;
-import org.junit.Before;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.opendatakit.logging.WebLogger;
-import org.opendatakit.logging.desktop.WebLoggerDesktopFactoryImpl;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
@@ -33,33 +36,39 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
-  private static DateUtils util;
+  private static final Locale NIGERIA_LOCALE = new Locale("en", "NG");
+  private static final Locale CAMEROON_LOCALE = new Locale("fr", "CM");
+
+  private static final TimeZone NIGERIA_TIME_ZONE = TimeZone.getTimeZone("Africa/Lagos");
+  private static final TimeZone CAMEROON_TIME_ZONE = TimeZone.getTimeZone("Africa/Douala");
+  private static final TimeZone LA_TIME_ZONE = TimeZone.getTimeZone("America/Los_Angeles");
+  private static final TimeZone TORONTO_TIME_ZONE = TimeZone.getTimeZone("America/Toronto");
+  private static final TimeZone LONDON_TIME_ZONE = TimeZone.getTimeZone("Europe/London");
+  private static final TimeZone ITALY_TIME_ZONE = TimeZone.getTimeZone("Europe/Rome");
 
   @BeforeClass
   public static void oneTimeSetUp() {
     StaticStateManipulator.get().reset();
-    WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
-
-    // Set up TimeZone and DateUtils
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    util = new DateUtils(Locale.US, tz);
   }
 
   @Test
   public void validifyDateValue_withDateInput_returnsFormattedDate() {
-    String value = util.validifyDateValue("3/4/2015");
-    
-    String expected = "2015-03-04T";
+    // Set up TimeZone and DateUtils
+    DateUtils dateUtil = new DateUtils(NIGERIA_LOCALE, NIGERIA_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("3/4/2015");
+
+    String expected = getTimeString(DateTime.parse("2015-03-04T")) ;
     assertEquals(expected, value.substring(0,expected.length()));
   }
 
   @Test
   public void validifyDateValue_withNowInput_returnsFormattedCurrentDate() {
-    String value = util.validifyDateValue("now");
+    DateUtils dateUtil = new DateUtils(CAMEROON_LOCALE, CAMEROON_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("now");
     assertNotNull(value);
 
     DateTime now = new DateTime();
-    String expectedFormattedDate = util.formatDateTimeForDb(now);
+    String expectedFormattedDate = getTimeString(now);
 
     // This is to take the slight delay when checking for output into consideration
     int periodIndex = expectedFormattedDate.indexOf('.');
@@ -68,36 +77,55 @@ public class DateUtilsTest {
 
   @Test
   public void validifyDateValue_withfutureTimeInput_returnsTimeInTheFuture() {
-    String value = util.validifyDateValue("now + 10m");
+    DateUtils dateUtil = new DateUtils(Locale.CANADA, TORONTO_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("now + 10m");
     assertNotNull(value);
 
     DateTime nowPlus10Minutes = new DateTime().plusMinutes(10);
-    String expectedFormattedDate = util.formatDateTimeForDb(nowPlus10Minutes);
+    String expectedFormattedDate = getTimeString(nowPlus10Minutes);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
 
   @Test
   public void validifyDateValue_withPastTimeInput_returnsTimeInThePast() {
-    String value = util.validifyDateValue("now - 3h");
+    DateUtils dateUtil = new DateUtils(Locale.US, LA_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("now - 3h");
     assertNotNull(value);
 
     DateTime nowMinus3Hours = new DateTime().minusHours(3);
-    String expectedFormattedDate = util.formatDateTimeForDb(nowMinus3Hours);
+    String expectedFormattedDate = getTimeString(nowMinus3Hours);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
 
   @Test
   public void validifyDateValue_withUnsupportedUnitInput_returnsNull() {
-    String value = util.validifyDateValue("now - 3y");
+    DateUtils dateUtil = new DateUtils(Locale.UK, LONDON_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("now - 3y");
     assertNull(value);
   }
 
   @Test
   public void validifyDateValue_withInvalidTimeFormat_returnsNull() {
-    String value = util.validifyDateValue("invalid-date");
+    DateUtils dateUtil = new DateUtils(Locale.ITALY, ITALY_TIME_ZONE);
+    String value = dateUtil.validifyDateValue("invalid-date");
     assertNull(value);
+  }
+
+  private String getTimeString(DateTime time){
+    // convert to a nanosecond-extended iso8601-style UTC date yyyy-mm-ddTHH:MM:SS.sssssssss
+    String partialPattern = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    Calendar calendar = GregorianCalendar.getInstance(new SimpleTimeZone(0, "UT"));
+
+    SimpleDateFormat fmt = new SimpleDateFormat(partialPattern, Locale.ROOT);
+    fmt.setCalendar(calendar);
+    Date d = new Date(time.getMillis());
+    return fmt.format(d) + "000000";
+  }
+  @AfterClass
+  public static void oneTimeTearDown() {
+    StaticStateManipulator.get().reset();
   }
 
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -33,16 +33,14 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
-  private DateUtils util;
+  private static DateUtils util;
 
   @BeforeClass
   public static void oneTimeSetUp() {
     StaticStateManipulator.get().reset();
     WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
-  }
 
-  @Before
-  public void setup() {
+    // Set up TimeZone and DateUtils
     TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
     util = new DateUtils(Locale.US, tz);
   }
@@ -56,7 +54,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testNowInput() {
+  public void validifyDateValue_withNowInput_returnsFormattedCurrentDate() {
     String value = util.validifyDateValue("now");
     assertNotNull(value);
 
@@ -69,7 +67,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testTimeAddition() {
+  public void validifyDateValue_withfutureTimeInput_returnsTimeInTheFuture() {
     String value = util.validifyDateValue("now + 10m");
     assertNotNull(value);
 
@@ -80,7 +78,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testTimeSubtraction() {
+  public void validifyDateValue_withPastTimeInput_returnsTimeInThePast() {
     String value = util.validifyDateValue("now - 3h");
     assertNotNull(value);
 
@@ -91,13 +89,13 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testInvalidTime() {
+  public void validifyDateValue_withUnsupportedUnitInput_returnsNull() {
     String value = util.validifyDateValue("now - 3y");
     assertNull(value);
   }
 
   @Test
-  public void testInvalidTimeFormat() {
+  public void validifyDateValue_withInvalidTimeFormat_returnsNull() {
     String value = util.validifyDateValue("invalid-date");
     assertNull(value);
   }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -15,6 +15,7 @@
 package org.opendatakit.utilities;
 
 import org.joda.time.DateTime;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
+  private DateUtils util;
 
   @BeforeClass
   public static void oneTimeSetUp() {
@@ -39,11 +41,14 @@ public class DateUtilsTest {
     WebLogger.setFactory(new WebLoggerDesktopFactoryImpl());
   }
 
+  @Before
+  public void setup() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    util = new DateUtils(Locale.US, tz);
+  }
+
   @Test
   public void testDateInterpretation() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-    
     String value = util.validifyDateValue("3/4/2015");
     
     String expected = "2015-03-04T";
@@ -52,9 +57,6 @@ public class DateUtilsTest {
 
   @Test
   public void testNowInput() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now");
     assertNotNull(value);
 
@@ -68,9 +70,6 @@ public class DateUtilsTest {
 
   @Test
   public void testTimeAddition() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now + 10m");
     assertNotNull(value);
 
@@ -82,9 +81,6 @@ public class DateUtilsTest {
 
   @Test
   public void testTimeSubtraction() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now - 3h");
     assertNotNull(value);
 
@@ -96,18 +92,12 @@ public class DateUtilsTest {
 
   @Test
   public void testInvalidTime() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("now - 3y");
     assertNull(value);
   }
 
   @Test
   public void testInvalidTimeFormat() {
-    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
-    DateUtils util = new DateUtils(Locale.US, tz);
-
     String value = util.validifyDateValue("invalid-date");
     assertNull(value);
   }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -46,7 +46,7 @@ public class DateUtilsTest {
   }
 
   @Test
-  public void testDateInterpretation() {
+  public void validifyDateValue_withDateInput_returnsFormattedDate() {
     String value = util.validifyDateValue("3/4/2015");
     
     String expected = "2015-03-04T";

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -14,6 +14,7 @@
 
 package org.opendatakit.utilities;
 
+import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +26,9 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateUtilsTest {
@@ -44,6 +48,68 @@ public class DateUtilsTest {
     
     String expected = "2015-03-04T";
     assertEquals(expected, value.substring(0,expected.length()));
+  }
+
+  @Test
+  public void testNowInput() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now");
+    assertNotNull(value);
+
+    DateTime now = new DateTime();
+    String expectedFormattedDate = util.formatDateTimeForDb(now);
+
+    // This is to take the slight delay when checking for output into consideration
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testTimeAddition() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now + 10m");
+    assertNotNull(value);
+
+    DateTime nowPlus10Minutes = new DateTime().plusMinutes(10);
+    String expectedFormattedDate = util.formatDateTimeForDb(nowPlus10Minutes);
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testTimeSubtraction() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now - 3h");
+    assertNotNull(value);
+
+    DateTime nowMinus3Hours = new DateTime().minusHours(3);
+    String expectedFormattedDate = util.formatDateTimeForDb(nowMinus3Hours);
+    int periodIndex = expectedFormattedDate.indexOf('.');
+    assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
+  }
+
+  @Test
+  public void testInvalidTime() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("now - 3y");
+    assertNull(value);
+  }
+
+  @Test
+  public void testInvalidTimeFormat() {
+    TimeZone tz = TimeZone.getTimeZone(TimeZone.getAvailableIDs()[0]);
+    DateUtils util = new DateUtils(Locale.US, tz);
+
+    String value = util.validifyDateValue("invalid-date");
+    assertNull(value);
   }
 
 }

--- a/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/utilities/DateUtilsTest.java
@@ -26,7 +26,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
@@ -57,7 +56,7 @@ public class DateUtilsTest {
     DateUtils dateUtil = new DateUtils(NIGERIA_LOCALE, NIGERIA_TIME_ZONE);
     String value = dateUtil.validifyDateValue("3/4/2015");
 
-    String expected = getTimeString(DateTime.parse("2015-03-04T")) ;
+    String expected = getTimeString(DateTime.parse("2015-03-04T"), NIGERIA_LOCALE, NIGERIA_TIME_ZONE) ;
     assertEquals(expected, value.substring(0,expected.length()));
   }
 
@@ -68,7 +67,7 @@ public class DateUtilsTest {
     assertNotNull(value);
 
     DateTime now = new DateTime();
-    String expectedFormattedDate = getTimeString(now);
+    String expectedFormattedDate = getTimeString(now, CAMEROON_LOCALE, CAMEROON_TIME_ZONE);
 
     // This is to take the slight delay when checking for output into consideration
     int periodIndex = expectedFormattedDate.indexOf('.');
@@ -82,7 +81,7 @@ public class DateUtilsTest {
     assertNotNull(value);
 
     DateTime nowPlus10Minutes = new DateTime().plusMinutes(10);
-    String expectedFormattedDate = getTimeString(nowPlus10Minutes);
+    String expectedFormattedDate = getTimeString(nowPlus10Minutes, Locale.CANADA, TORONTO_TIME_ZONE);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
@@ -94,7 +93,7 @@ public class DateUtilsTest {
     assertNotNull(value);
 
     DateTime nowMinus3Hours = new DateTime().minusHours(3);
-    String expectedFormattedDate = getTimeString(nowMinus3Hours);
+    String expectedFormattedDate = getTimeString(nowMinus3Hours, Locale.US, LA_TIME_ZONE);
     int periodIndex = expectedFormattedDate.indexOf('.');
     assertTrue(value.startsWith(expectedFormattedDate.substring(0, periodIndex + 1)));
   }
@@ -113,12 +112,12 @@ public class DateUtilsTest {
     assertNull(value);
   }
 
-  private String getTimeString(DateTime time){
+  private String getTimeString(DateTime time, Locale locale, TimeZone timeZone){
     // convert to a nanosecond-extended iso8601-style UTC date yyyy-mm-ddTHH:MM:SS.sssssssss
     String partialPattern = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    Calendar calendar = GregorianCalendar.getInstance(new SimpleTimeZone(0, "UT"));
+    Calendar calendar = GregorianCalendar.getInstance(timeZone);
 
-    SimpleDateFormat fmt = new SimpleDateFormat(partialPattern, Locale.ROOT);
+    SimpleDateFormat fmt = new SimpleDateFormat(partialPattern, locale);
     fmt.setCalendar(calendar);
     Date d = new Date(time.getMillis());
     return fmt.format(d) + "000000";


### PR DESCRIPTION
### Updating [PR 284](https://github.com/odk-x/androidlibrary/pull/284)

- This PR contains [PR 284](https://github.com/odk-x/androidlibrary/pull/284) and updated the test time zone to use various time zones.
- Appropriate constants were created for use
- The expected value for `validifyDateValue_withfutureTimeInput_returnsTimeInTheFuture` was updated to use the test class function.
- ColoRuleTest is also rearranged and cleaned up in this PR

### Coverage report given below

> <img width="1331" alt="image" src="https://github.com/user-attachments/assets/ddfd57a5-6d5c-485e-ad9c-dedd5652c21b" />

### Test Results
![image](https://github.com/user-attachments/assets/e6946a74-fcd0-47fe-a601-038b48acab65)

