### PR TITLE
Db handler test

### DIFF
--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
@@ -1,0 +1,49 @@
+package org.opendatakit.database.Service;
+
+import android.os.Parcel;
+import org.junit.Before;
+import org.junit.Test;
+import org.opendatakit.database.service.DbHandle;
+
+import static org.junit.Assert.*;
+public class DbHandleTest {
+    private static final String TEST_DATABASE_HANDLE = "testDatabaseHandle";
+    private DbHandle dbHandle;
+    @Before
+    public void setUp() {
+        dbHandle = new DbHandle(TEST_DATABASE_HANDLE);
+    }
+
+    @Test
+    public void constructor_ValidDatabaseHandle_CreatesInstance() {
+        assertNotNull(dbHandle);
+        assertEquals(TEST_DATABASE_HANDLE, dbHandle.getDatabaseHandle());
+    }
+    @Test
+    public void writeToParcel_CreatesParcel() {
+        Parcel parcel = Parcel.obtain();
+        dbHandle.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0); // Reset the parcel for reading
+        DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
+        assertEquals(TEST_DATABASE_HANDLE, createdFromParcel.getDatabaseHandle());
+        parcel.recycle(); // Clean up the parcel object
+    }
+    @Test
+    public void readFromParcel_NullDatabaseHandle_ThrowsException() {
+        Parcel parcel = Parcel.obtain();
+        parcel.writeString(null); // Write null to the parcel
+        parcel.setDataPosition(0); // Reset the parcel for reading
+        try {
+            DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
+            fail("Expected IllegalArgumentException to be thrown");
+        } catch (IllegalArgumentException e) {
+            // Exception was thrown as expected
+        } finally {
+            parcel.recycle(); // Clean up the parcel object
+        }
+    }
+    @Test
+    public void describeContents_ReturnsZero() {
+        assertEquals(0, dbHandle.describeContents());
+    }
+}

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
@@ -1,45 +1,27 @@
 package org.opendatakit.database.Service;
 
-import android.os.Parcel;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.opendatakit.database.service.DbHandle;
 
-import static org.junit.Assert.*;
 public class DbHandleTest {
     private static final String TEST_DATABASE_HANDLE = "testDatabaseHandle";
     private DbHandle dbHandle;
+
     @Before
     public void setUp() {
         dbHandle = new DbHandle(TEST_DATABASE_HANDLE);
     }
 
     @Test
-    public void constructor_ValidDatabaseHandle_CreatesInstance() {
+    public void constructor_withValidDatabaseHandle_createsInstance() {
         assertNotNull(dbHandle);
         assertEquals(TEST_DATABASE_HANDLE, dbHandle.getDatabaseHandle());
     }
-    @Test
-    public void writeToParcel_CreatesParcel() {
-        Parcel parcel = Parcel.obtain();
-        dbHandle.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0); 
-        DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
-        assertEquals(TEST_DATABASE_HANDLE, createdFromParcel.getDatabaseHandle());
-        parcel.recycle(); 
-    }
-    @Test
-    public void readFromParcel_NullDatabaseHandle_ThrowsException() {
-        Parcel parcel = Parcel.obtain();
-        parcel.writeString(null); 
-        parcel.setDataPosition(0); 
-            DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
-            fail("Expected IllegalArgumentException to be thrown");
-        } catch (IllegalArgumentException e) {
-        } finally {
-            parcel.recycle(); 
-        }
-    }
+
     @Test
     public void describeContents_ReturnsZero() {
         assertEquals(0, dbHandle.describeContents());

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/Service/DbHandleTest.java
@@ -23,23 +23,21 @@ public class DbHandleTest {
     public void writeToParcel_CreatesParcel() {
         Parcel parcel = Parcel.obtain();
         dbHandle.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0); // Reset the parcel for reading
+        parcel.setDataPosition(0); 
         DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
         assertEquals(TEST_DATABASE_HANDLE, createdFromParcel.getDatabaseHandle());
-        parcel.recycle(); // Clean up the parcel object
+        parcel.recycle(); 
     }
     @Test
     public void readFromParcel_NullDatabaseHandle_ThrowsException() {
         Parcel parcel = Parcel.obtain();
-        parcel.writeString(null); // Write null to the parcel
-        parcel.setDataPosition(0); // Reset the parcel for reading
-        try {
+        parcel.writeString(null); 
+        parcel.setDataPosition(0); 
             DbHandle createdFromParcel = DbHandle.CREATOR.createFromParcel(parcel);
             fail("Expected IllegalArgumentException to be thrown");
         } catch (IllegalArgumentException e) {
-            // Exception was thrown as expected
         } finally {
-            parcel.recycle(); // Clean up the parcel object
+            parcel.recycle(); 
         }
     }
     @Test


### PR DESCRIPTION
Said to contains unit tests for the DbHandle class, which is responsible for handling database references in the ODK-X application. Ref [PR 291](https://github.com/odk-x/androidlibrary/pull/291)

This PR removes the non-compilable code to allow a successful build.