### PR TITLE
Added tests for KeyStoreValueUtils

### DIFF
--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/KeyValueStoreEntryTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/KeyValueStoreEntryTest.java
@@ -214,3 +214,4 @@ public class KeyValueStoreEntryTest {
     }
 
 }
+

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/KeyValueStoreEntryTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/KeyValueStoreEntryTest.java
@@ -1,0 +1,216 @@
+package org.opendatakit.database.data;
+
+import static org.junit.Assert.*;
+
+import android.os.Parcel;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@SuppressWarnings("ALL")
+@RunWith(AndroidJUnit4.class)
+public class KeyValueStoreEntryTest {
+
+    private KeyValueStoreEntry ENTRY_1;
+    private KeyValueStoreEntry ENTRY_2;
+
+    // Constants class containing content to be used in tests
+    private static class Constants {
+        private static final String TABLE_ID = "testTable";
+
+        // first test entry contents
+        private static final String PARTITION1 = "partition1";
+        private static final String ASPECT1 = "aspect1";
+        private static final String KEY1 = "key1";
+        private static final String TYPE1 = "number";
+        private static final String VALUE1 = "value1";
+
+        // second test entry contents
+        private static final String PARTITION2 = "partition2";
+        private static final String ASPECT2 = "aspect2";
+        private static final String KEY2 = "key2";
+        private static final String TYPE2 = "number";
+        private static final String VALUE2 = "value2";
+    }
+
+    // Test that the KeyValueStoreEntry is initialized correctly and is empty
+    @Test
+    public void testKeyValueStoreEntryInitialization() {
+        ENTRY_1 = new KeyValueStoreEntry();
+        assertNull(ENTRY_1.tableId);
+        assertNull(ENTRY_1.partition);
+        assertNull(ENTRY_1.aspect);
+        assertNull(ENTRY_1.key);
+        assertNull(ENTRY_1.type);
+        assertNull(ENTRY_1.value);
+    }
+
+    @Before
+    public void setUp() {
+        // First test entry
+        ENTRY_1 = new KeyValueStoreEntry();
+        ENTRY_1.tableId = Constants.TABLE_ID;
+        ENTRY_1.partition = Constants.PARTITION1;
+        ENTRY_1.aspect = Constants.ASPECT1;
+        ENTRY_1.key = Constants.KEY1;
+        ENTRY_1.type = Constants.TYPE1;
+        ENTRY_1.value = Constants.VALUE1;
+
+        // Second test entry
+        ENTRY_2 = new KeyValueStoreEntry();
+        ENTRY_2.tableId = Constants.TABLE_ID;
+        ENTRY_2.partition = Constants.PARTITION2;
+        ENTRY_2.aspect = Constants.ASPECT2;
+        ENTRY_2.key = Constants.KEY2;
+        ENTRY_2.type = Constants.TYPE2;
+        ENTRY_2.value = Constants.VALUE2;
+    }
+
+    @Test
+    public void testToString() {
+        String str = ENTRY_1.toString();
+        assertTrue(str.contains(Constants.TABLE_ID));
+        assertTrue(str.contains(Constants.PARTITION1));
+        assertTrue(str.contains(Constants.ASPECT1));
+        assertTrue(str.contains(Constants.KEY1));
+        assertTrue(str.contains(Constants.TYPE1));
+        assertTrue(str.contains(Constants.VALUE1));
+    }
+
+    @Test
+    public void testHashCodeConsistency() {
+
+        Parcel parcel = Parcel.obtain();
+        ENTRY_1.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        // Create a new KeyStoreValueEntry object from the parcel
+        KeyValueStoreEntry createdFromParcel = new KeyValueStoreEntry(parcel);
+
+        // Checking hash code consistency.
+        // If the data contained each KeyValueStoreEntry object
+        // is the same, the hash codes should be the same
+        assertEquals(ENTRY_1.hashCode(), createdFromParcel.hashCode());
+    }
+
+    @Test
+    public void testHashCodeDifference() {
+        // Checking hash code consistency.
+        // If the data contained within each KeyValueStoreEntry object is
+        // different, then the hash codes should be the different as well.
+        assertNotEquals(ENTRY_1.hashCode(), ENTRY_2.hashCode());
+    }
+
+    @Test
+    public void testEqualsNull() {
+        // Test for equality against null objects
+        KeyValueStoreEntry key = null;
+        assertFalse(ENTRY_1.equals(key));
+    }
+
+    @Test
+    public void testEqualsSameObject() {
+        // Test same instance of an object for equality
+        assertTrue(ENTRY_1.equals(ENTRY_1));
+    }
+
+    @Test
+    public void testEqualsDifferentObject() {
+        // Test different objects of the same type for equality
+        assertFalse(ENTRY_1.equals(ENTRY_2));
+    }
+
+    @Test
+    public void testEqualsTypeMismatch() {
+        String str = "string";
+        // Test for equality against an object of a different type
+        assertFalse(ENTRY_1.equals(str));
+    }
+
+    @Test
+    public void testCompareToPartition() {
+        // Test for partition comparison
+
+        // ENTRY_1 should be placed before ENTRY_2
+        assertTrue(ENTRY_1.compareTo(ENTRY_2) < 0);
+
+        // ENTRY_2 should be placed after ENTRY_1
+        assertTrue(ENTRY_2.compareTo(ENTRY_1) > 0);
+    }
+
+    @Test
+    public void testCompareToAspect() {
+        // Test for aspect comparison
+
+        // Modifying ENTRY_2 to have the same partition
+        // as ENTRY_1 and a different aspect
+        ENTRY_2.partition = Constants.PARTITION1;
+
+        // ENTRY_1 should be placed before ENTRY_2
+        assertTrue(ENTRY_1.compareTo(ENTRY_2) < 0);
+
+        // ENTRY_2 should be placed after ENTRY_1
+        assertTrue(ENTRY_2.compareTo(ENTRY_1) > 0);
+    }
+
+    @Test
+    public void testCompareToKey() {
+        // Test for key comparison
+
+        // Modifying ENTRY_2 to have the same partition
+        // and aspect as ENTRY_1 and only a different key
+        ENTRY_2.partition = Constants.PARTITION1;
+        ENTRY_2.aspect = Constants.ASPECT1;
+
+        // ENTRY_1 should be placed before ENTRY_2
+        assertTrue(ENTRY_1.compareTo(ENTRY_2) < 0);
+
+        // ENTRY_2 should be placed after ENTRY_1
+        assertTrue(ENTRY_2.compareTo(ENTRY_1) > 0);
+    }
+
+    @Test
+    public void testCompareToEquality() {
+        // Test for equality comparison
+
+        // Modifying ENTRY_2 to have the same partition
+        // and aspect and key as ENTRY_1
+        ENTRY_2.partition = Constants.PARTITION1;
+        ENTRY_2.aspect = Constants.ASPECT1;
+        ENTRY_2.key = Constants.KEY1;
+
+        // Order should not matter for in an equality test
+        // ENTRY_1 should be equal to ENTRY_2
+        assertEquals(0, ENTRY_1.compareTo(ENTRY_2));
+
+        // ENTRY_2 should be equal to ENTRY_1
+        assertEquals(0, ENTRY_2.compareTo(ENTRY_1));
+    }
+
+    @Test
+    public void testDescribeContents() {
+        assertEquals(0, ENTRY_1.describeContents());
+    }
+
+    // Test for data integrity during reading and writing to a parcel
+    // (serialization and deserialization)
+    @Test
+    public void testWriteToParcel() {
+        // Write the KeyStoreValueEntry object to a parcel
+        Parcel parcel = Parcel.obtain();
+        ENTRY_1.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        // Read entry data and verify that the data is the same
+        assertEquals(Constants.TABLE_ID, parcel.readString());
+        assertEquals(Constants.PARTITION1, parcel.readString());
+        assertEquals(Constants.ASPECT1, parcel.readString());
+        assertEquals(Constants.KEY1, parcel.readString());
+        assertEquals(Constants.TYPE1, parcel.readString());
+        assertEquals(Constants.VALUE1, parcel.readString());
+    }
+
+}

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -1,0 +1,100 @@
+package org.opendatakit.database.data;
+
+import android.os.Parcel;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class TableMetaDataEntriesTest {
+
+    //
+    TableMetaDataEntries testMetaDataEntries;
+    private final String TABLE_ID = "testTable";
+    private final String REV_ID = "revId";
+    KeyValueStoreEntry entry1 = new KeyValueStoreEntry();
+    KeyValueStoreEntry entry2 = new KeyValueStoreEntry();
+
+    @Before
+    public void setUp() {
+        testMetaDataEntries = new TableMetaDataEntries(TABLE_ID, REV_ID);
+
+        // first test entry
+
+        entry1.tableId = TABLE_ID;
+        entry1.partition = "partition1";
+        entry1.aspect = "aspect1";
+        entry1.key = "key1";
+        entry1.type = "number";
+        entry1.value = "value1";
+
+        // second test entry
+        entry2.tableId = TABLE_ID;
+        entry2.partition = "partition2";
+        entry2.aspect = "aspect2";
+        entry2.key = "key2";
+        entry2.type = "number";
+        entry2.value = "value2";
+
+    }
+
+    @Test
+    public void testDatabaseInitialization() { // test that an empty database is initialized
+        assertEquals(TABLE_ID, testMetaDataEntries.getTableId());
+        assertEquals(REV_ID, testMetaDataEntries.getRevId());
+        assertTrue(testMetaDataEntries.getEntries().isEmpty());
+    }
+
+    @Test
+    public void testAddEntry() {
+        testMetaDataEntries.addEntry(entry1);
+        testMetaDataEntries.addEntry(entry2);
+
+        ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
+        assertEquals(2, entries.size());
+        assertEquals(entry1, entries.get(0));
+        assertEquals(entry2, entries.get(1));
+    }
+
+    @Test
+    public void testWriteToParcel() {
+        testMetaDataEntries.addEntry(entry1);
+
+        // Write the testMetaDataEntries object to a parcel
+        Parcel parcel = Parcel.obtain();
+        testMetaDataEntries.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+
+        // Create new MetaDataEntries object from the parcel
+        TableMetaDataEntries createdFromParcel = TableMetaDataEntries.CREATOR.createFromParcel(parcel);
+
+        // Verify that the data is the same
+        assertEquals(testMetaDataEntries.getTableId(), createdFromParcel.getTableId());
+        assertEquals(testMetaDataEntries.getRevId(), createdFromParcel.getRevId());
+        assertEquals(testMetaDataEntries.getEntries().size(), createdFromParcel.getEntries().size());
+
+        assertEquals(testMetaDataEntries.getEntries().get(0).tableId, createdFromParcel.getEntries().get(0).tableId);
+        assertEquals(testMetaDataEntries.getEntries().get(0).partition, createdFromParcel.getEntries().get(0).partition);
+        assertEquals(testMetaDataEntries.getEntries().get(0).aspect, createdFromParcel.getEntries().get(0).aspect);
+        assertEquals(testMetaDataEntries.getEntries().get(0).key, createdFromParcel.getEntries().get(0).key);
+        assertEquals(testMetaDataEntries.getEntries().get(0).type, createdFromParcel.getEntries().get(0).type);
+        assertEquals(testMetaDataEntries.getEntries().get(0).value, createdFromParcel.getEntries().get(0).value);
+    }
+
+    @Test
+    public void testEntryOrderPreservation() {
+        testMetaDataEntries.addEntry(entry2);
+        testMetaDataEntries.addEntry(entry1);
+
+        ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
+        assertEquals(entry2, entries.get(0));
+        assertEquals(entry1, entries.get(1));
+    }
+
+
+}

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 
+@SuppressWarnings("ALL")
 @RunWith(AndroidJUnit4.class)
 public class TableMetaDataEntriesTest {
 

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -14,18 +14,18 @@ import static org.junit.Assert.*;
 @RunWith(AndroidJUnit4.class)
 public class TableMetaDataEntriesTest {
 
-    private TableMetaDataEntries testMetaDataEntries;
+    public TableMetaDataEntries testMetaDataEntries;
 
     private final KeyValueStoreEntry ENTRY_1 = new KeyValueStoreEntry();
     private final KeyValueStoreEntry ENTRY_2 = new KeyValueStoreEntry();
 
-    // Contants class containing content to be used in tests
-    private static class Constants {
+    // Constants class containing content to be used in tests
+    public static class Constants {
 
         private static final String TABLE_ID = "testTable";
         private static final String REV_ID = "revId";
 
-        // first test entry constents
+        // first test entry contents
         private static final String PARTITION1 = "partition1";
         private static final String ASPECT1 = "aspect1";
         private static final String KEY1 = "key1";

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -14,32 +14,31 @@ import static org.junit.Assert.*;
 public class TableMetaDataEntriesTest {
 
     //
-    TableMetaDataEntries testMetaDataEntries;
+    private TableMetaDataEntries testMetaDataEntries;
     private final String TABLE_ID = "testTable";
     private final String REV_ID = "revId";
-    KeyValueStoreEntry entry1 = new KeyValueStoreEntry();
-    KeyValueStoreEntry entry2 = new KeyValueStoreEntry();
+    private final KeyValueStoreEntry ENTRY_1 = new KeyValueStoreEntry();
+    private final KeyValueStoreEntry ENTRY_2 = new KeyValueStoreEntry();
 
     @Before
     public void setUp() {
         testMetaDataEntries = new TableMetaDataEntries(TABLE_ID, REV_ID);
 
         // first test entry
-
-        entry1.tableId = TABLE_ID;
-        entry1.partition = "partition1";
-        entry1.aspect = "aspect1";
-        entry1.key = "key1";
-        entry1.type = "number";
-        entry1.value = "value1";
+        ENTRY_1.tableId = TABLE_ID;
+        ENTRY_1.partition = "partition1";
+        ENTRY_1.aspect = "aspect1";
+        ENTRY_1.key = "key1";
+        ENTRY_1.type = "number";
+        ENTRY_1.value = "value1";
 
         // second test entry
-        entry2.tableId = TABLE_ID;
-        entry2.partition = "partition2";
-        entry2.aspect = "aspect2";
-        entry2.key = "key2";
-        entry2.type = "number";
-        entry2.value = "value2";
+        ENTRY_2.tableId = TABLE_ID;
+        ENTRY_2.partition = "partition2";
+        ENTRY_2.aspect = "aspect2";
+        ENTRY_2.key = "key2";
+        ENTRY_2.type = "number";
+        ENTRY_2.value = "value2";
 
     }
 
@@ -52,13 +51,13 @@ public class TableMetaDataEntriesTest {
 
     @Test
     public void testAddEntry() {
-        testMetaDataEntries.addEntry(entry1);
-        testMetaDataEntries.addEntry(entry2);
+        testMetaDataEntries.addEntry(ENTRY_1);
+        testMetaDataEntries.addEntry(ENTRY_2);
 
         ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
         assertEquals(2, entries.size());
-        assertEquals(entry1, entries.get(0));
-        assertEquals(entry2, entries.get(1));
+        assertEquals(ENTRY_1, entries.get(0));
+        assertEquals(ENTRY_2, entries.get(1));
     }
 
     @Test
@@ -68,7 +67,7 @@ public class TableMetaDataEntriesTest {
 
     @Test
     public void testWriteToParcel() {
-        testMetaDataEntries.addEntry(entry1);
+        testMetaDataEntries.addEntry(ENTRY_1);
 
         // Write the testMetaDataEntries object to a parcel
         Parcel parcel = Parcel.obtain();
@@ -93,12 +92,12 @@ public class TableMetaDataEntriesTest {
 
     @Test
     public void testEntryOrderPreservation() {
-        testMetaDataEntries.addEntry(entry2);
-        testMetaDataEntries.addEntry(entry1);
+        testMetaDataEntries.addEntry(ENTRY_2);
+        testMetaDataEntries.addEntry(ENTRY_1);
 
         ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
-        assertEquals(entry2, entries.get(0));
-        assertEquals(entry1, entries.get(1));
+        assertEquals(ENTRY_2, entries.get(0));
+        assertEquals(ENTRY_1, entries.get(1));
     }
 
 

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -62,6 +62,11 @@ public class TableMetaDataEntriesTest {
     }
 
     @Test
+    public void testDescribeContents() {
+        assertEquals(0, testMetaDataEntries.describeContents());
+    }
+
+    @Test
     public void testWriteToParcel() {
         testMetaDataEntries.addEntry(entry1);
 

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -13,39 +13,58 @@ import static org.junit.Assert.*;
 @RunWith(AndroidJUnit4.class)
 public class TableMetaDataEntriesTest {
 
-    //
     private TableMetaDataEntries testMetaDataEntries;
-    private final String TABLE_ID = "testTable";
-    private final String REV_ID = "revId";
+
     private final KeyValueStoreEntry ENTRY_1 = new KeyValueStoreEntry();
     private final KeyValueStoreEntry ENTRY_2 = new KeyValueStoreEntry();
 
+    // Contants class containing content to be used in tests
+    private static class Constants {
+
+        private static final String TABLE_ID = "testTable";
+        private static final String REV_ID = "revId";
+
+        // first test entry constents
+        private static final String PARTITION1 = "partition1";
+        private static final String ASPECT1 = "aspect1";
+        private static final String KEY1 = "key1";
+        private static final String TYPE1 = "number";
+        private static final String VALUE1 = "value1";
+
+        // second test entry contents
+        private static final String PARTITION2 = "partition2";
+        private static final String ASPECT2 = "aspect2";
+        private static final String KEY2 = "key2";
+        private static final String TYPE2 = "number";
+        private static final String VALUE2 = "value2";
+    }
+
     @Before
     public void setUp() {
-        testMetaDataEntries = new TableMetaDataEntries(TABLE_ID, REV_ID);
+        testMetaDataEntries = new TableMetaDataEntries(Constants.TABLE_ID, Constants.REV_ID);
 
         // first test entry
-        ENTRY_1.tableId = TABLE_ID;
-        ENTRY_1.partition = "partition1";
-        ENTRY_1.aspect = "aspect1";
-        ENTRY_1.key = "key1";
-        ENTRY_1.type = "number";
-        ENTRY_1.value = "value1";
+        ENTRY_1.tableId = Constants.TABLE_ID;
+        ENTRY_1.partition = Constants.PARTITION1;
+        ENTRY_1.aspect = Constants.ASPECT1;
+        ENTRY_1.key = Constants.KEY1;
+        ENTRY_1.type = Constants.TYPE1;
+        ENTRY_1.value = Constants.VALUE1;
 
         // second test entry
-        ENTRY_2.tableId = TABLE_ID;
-        ENTRY_2.partition = "partition2";
-        ENTRY_2.aspect = "aspect2";
-        ENTRY_2.key = "key2";
-        ENTRY_2.type = "number";
-        ENTRY_2.value = "value2";
+        ENTRY_2.tableId = Constants.TABLE_ID;
+        ENTRY_2.partition = Constants.PARTITION2;
+        ENTRY_2.aspect = Constants.ASPECT2;
+        ENTRY_2.key = Constants.KEY2;
+        ENTRY_2.type = Constants.TYPE2;
+        ENTRY_2.value = Constants.VALUE2;
 
     }
 
     @Test
     public void testDatabaseInitialization() { // test that an empty database is initialized
-        assertEquals(TABLE_ID, testMetaDataEntries.getTableId());
-        assertEquals(REV_ID, testMetaDataEntries.getRevId());
+        assertEquals(Constants.TABLE_ID, testMetaDataEntries.getTableId());
+        assertEquals(Constants.REV_ID, testMetaDataEntries.getRevId());
         assertTrue(testMetaDataEntries.getEntries().isEmpty());
     }
 
@@ -54,10 +73,28 @@ public class TableMetaDataEntriesTest {
         testMetaDataEntries.addEntry(ENTRY_1);
         testMetaDataEntries.addEntry(ENTRY_2);
 
+        // Verify that the entries were added correctly
         ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
         assertEquals(2, entries.size());
         assertEquals(ENTRY_1, entries.get(0));
         assertEquals(ENTRY_2, entries.get(1));
+
+        // Verify that the contents of the entries are correct
+        // ENTRY_1
+        assertEquals(Constants.TABLE_ID, entries.get(0).tableId);
+        assertEquals(Constants.PARTITION1, entries.get(0).partition);
+        assertEquals(Constants.ASPECT1, entries.get(0).aspect);
+        assertEquals(Constants.KEY1, entries.get(0).key);
+        assertEquals(Constants.TYPE1, entries.get(0).type);
+        assertEquals(Constants.VALUE1, entries.get(0).value);
+
+        // ENTRY_2
+        assertEquals(Constants.TABLE_ID, entries.get(1).tableId);
+        assertEquals(Constants.PARTITION2, entries.get(1).partition);
+        assertEquals(Constants.ASPECT2, entries.get(1).aspect);
+        assertEquals(Constants.KEY2, entries.get(1).key);
+        assertEquals(Constants.TYPE2, entries.get(1).type);
+        assertEquals(Constants.VALUE2, entries.get(1).value);
     }
 
     @Test
@@ -99,6 +136,5 @@ public class TableMetaDataEntriesTest {
         assertEquals(ENTRY_2, entries.get(0));
         assertEquals(ENTRY_1, entries.get(1));
     }
-
-
 }
+

--- a/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
+++ b/androidlibrary_lib/src/androidTest/java/org/opendatakit/database/data/TableMetaDataEntriesTest.java
@@ -20,25 +20,43 @@ public class TableMetaDataEntriesTest {
     private final KeyValueStoreEntry ENTRY_1 = new KeyValueStoreEntry();
     private final KeyValueStoreEntry ENTRY_2 = new KeyValueStoreEntry();
 
+    // Contants class containing content to be used in tests
+    private static class Constants {
+
+        // first test entry constents
+        private static final String PARTITION1 = "partition1";
+        private static final String ASPECT1 = "aspect1";
+        private static final String KEY1 = "key1";
+        private static final String TYPE1 = "number";
+        private static final String VALUE1 = "value1";
+
+        // second test entry contents
+        private static final String PARTITION2 = "partition2";
+        private static final String ASPECT2 = "aspect2";
+        private static final String KEY2 = "key2";
+        private static final String TYPE2 = "number";
+        private static final String VALUE2 = "value2";
+    }
+
     @Before
     public void setUp() {
         testMetaDataEntries = new TableMetaDataEntries(TABLE_ID, REV_ID);
 
         // first test entry
         ENTRY_1.tableId = TABLE_ID;
-        ENTRY_1.partition = "partition1";
-        ENTRY_1.aspect = "aspect1";
-        ENTRY_1.key = "key1";
-        ENTRY_1.type = "number";
-        ENTRY_1.value = "value1";
+        ENTRY_1.partition = Constants.PARTITION1;
+        ENTRY_1.aspect = Constants.ASPECT1;
+        ENTRY_1.key = Constants.KEY1;
+        ENTRY_1.type = Constants.TYPE1;
+        ENTRY_1.value = Constants.VALUE1;
 
         // second test entry
         ENTRY_2.tableId = TABLE_ID;
-        ENTRY_2.partition = "partition2";
-        ENTRY_2.aspect = "aspect2";
-        ENTRY_2.key = "key2";
-        ENTRY_2.type = "number";
-        ENTRY_2.value = "value2";
+        ENTRY_2.partition = Constants.PARTITION2;
+        ENTRY_2.aspect = Constants.ASPECT2;
+        ENTRY_2.key = Constants.KEY2;
+        ENTRY_2.type = Constants.TYPE2;
+        ENTRY_2.value = Constants.VALUE2;
 
     }
 
@@ -54,10 +72,28 @@ public class TableMetaDataEntriesTest {
         testMetaDataEntries.addEntry(ENTRY_1);
         testMetaDataEntries.addEntry(ENTRY_2);
 
+        // Verify that the entries were added correctly
         ArrayList<KeyValueStoreEntry> entries = testMetaDataEntries.getEntries();
         assertEquals(2, entries.size());
         assertEquals(ENTRY_1, entries.get(0));
         assertEquals(ENTRY_2, entries.get(1));
+
+        // Verify that the contents of the entries are correct
+        // ENTRY_1
+        assertEquals(TABLE_ID, entries.get(0).tableId);
+        assertEquals(Constants.PARTITION1, entries.get(0).partition);
+        assertEquals(Constants.ASPECT1, entries.get(0).aspect);
+        assertEquals(Constants.KEY1, entries.get(0).key);
+        assertEquals(Constants.TYPE1, entries.get(0).type);
+        assertEquals(Constants.VALUE1, entries.get(0).value);
+
+        // ENTRY_2
+        assertEquals(TABLE_ID, entries.get(1).tableId);
+        assertEquals(Constants.PARTITION2, entries.get(1).partition);
+        assertEquals(Constants.ASPECT2, entries.get(1).aspect);
+        assertEquals(Constants.KEY2, entries.get(1).key);
+        assertEquals(Constants.TYPE2, entries.get(1).type);
+        assertEquals(Constants.VALUE2, entries.get(1).value);
     }
 
     @Test
@@ -99,6 +135,5 @@ public class TableMetaDataEntriesTest {
         assertEquals(ENTRY_2, entries.get(0));
         assertEquals(ENTRY_1, entries.get(1));
     }
-
-
 }
+

--- a/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/KeyValueStoreUtilsTest.java
+++ b/androidlibrary_lib/src/test/java/org/opendatakit/database/utilities/KeyValueStoreUtilsTest.java
@@ -1,0 +1,308 @@
+package org.opendatakit.database.utilities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.opendatakit.database.data.KeyValueStoreEntry;
+import org.opendatakit.aggregate.odktables.rest.ElementDataType;
+
+import java.util.ArrayList;
+
+public class KeyValueStoreUtilsTest {
+
+    private static final String TABLE_ID = "testTable";
+    private static final String PARTITION = "partition";
+    private static final String ASPECT = "aspect";
+    private static final String KEY = "key";
+    private static final ElementDataType TYPE_NUMBER = ElementDataType.number;
+    private static final ElementDataType TYPE_INTEGER = ElementDataType.integer;
+    private static final ElementDataType TYPE_BOOL = ElementDataType.bool;
+    private static final ElementDataType TYPE_STRING = ElementDataType.string;
+    private static final ElementDataType TYPE_ARRAY = ElementDataType.array;
+    private static final ElementDataType TYPE_OBJECT = ElementDataType.object;
+    private static final String VALUE_NUMBER = "404.22";
+    private static final String VALUE_INTEGER = "404";
+    private static final String VALUE_BOOL_TRUE = "true";
+    private static final String VALUE_BOOL_FALSE = "false";
+    private static final String VALUE_BOOL_ZERO = "0";
+    private static final String VALUE_BOOL_ONE = "1";
+    private static final String VALUE_STRING = "testString";
+    private static final String VALUE_MISMATCH = "wrongValue";
+    private static final String VALUE_ARRAY = "[\"testItem1\", \"testItem2\"]";
+    private static final String VALUE_OBJECT = "{\"key\":\"value\"}";
+    private static final String TEST_APP_NAME = "testAppName";
+
+
+    @Test
+    public void testBuildEntry() {
+        KeyValueStoreEntry entry = KeyValueStoreUtils.buildEntry(TABLE_ID, PARTITION, ASPECT, KEY, TYPE_INTEGER, VALUE_INTEGER);
+        assertEquals(TABLE_ID, entry.tableId);
+        assertEquals(PARTITION, entry.partition);
+        assertEquals(ASPECT, entry.aspect);
+        assertEquals(KEY, entry.key);
+        assertEquals(TYPE_INTEGER.name(), entry.type);
+        assertEquals(VALUE_INTEGER, entry.value);
+    }
+
+    @Test
+    public void testGetNumber_NullEntry() {
+        assertNull(KeyValueStoreUtils.getNumber(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetNumber_TypeMismatch() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_NUMBER;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getNumber(entry);
+    }
+
+    @Test
+    public void testGetNumber_Success() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_NUMBER.name();
+        entry.value = VALUE_NUMBER;
+
+        assertEquals(Double.parseDouble(VALUE_NUMBER), KeyValueStoreUtils.getNumber(entry), 0.001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetNumber_InvalidNumber() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_MISMATCH;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getNumber(entry);
+    }
+
+    @Test
+    public void testGetInteger_NullEntry() {
+        KeyValueStoreUtils.getNumber(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetInteger_TypeMismatch() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_NUMBER.name();
+        entry.value = VALUE_NUMBER;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getInteger(entry);
+    }
+
+    @Test
+    public void testGetInteger_Success() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_INTEGER;
+        entry.key = KEY;
+
+        assertEquals(Integer.valueOf(VALUE_INTEGER), KeyValueStoreUtils.getInteger(entry));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetInteger_InvalidNumber() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_MISMATCH;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getInteger(entry);
+    }
+
+    @Test
+    public void testGetBoolean_NullEntry() {
+        KeyValueStoreUtils.getBoolean(null);
+    }
+    @Test
+    public void testGetBoolean_NullValue() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = null;
+        entry.key = KEY;
+
+        assertNull(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBoolean_TypeMismatch() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_MISMATCH;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getBoolean(entry);
+    }
+
+    @Test
+    public void testGetBoolean_SuccessTrue() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = VALUE_BOOL_TRUE;
+        entry.key = KEY;
+
+        assertTrue(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test
+    public void testGetBoolean_SuccessFalse() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = VALUE_BOOL_FALSE;
+        entry.key = KEY;
+
+        assertFalse(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test
+    public void testGetBoolean_SuccessOne() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = VALUE_BOOL_ONE;
+        entry.key = KEY;
+
+        assertTrue(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test
+    public void testGetBoolean_SuccessZero() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = VALUE_BOOL_ZERO;
+        entry.key = KEY;
+
+        assertFalse(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetBoolean_InvalidBoolean() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_BOOL.name();
+        entry.value = VALUE_MISMATCH;
+        entry.key = KEY;
+
+        assertTrue(KeyValueStoreUtils.getBoolean(entry));
+    }
+
+    @Test
+    public void testGetString_NullEntry() {
+        assertNull(KeyValueStoreUtils.getString(null));
+    }
+
+    @Test
+    public void testGetString_NullValue() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_STRING.name();
+        entry.value = null;
+        entry.key = KEY;
+
+        assertNull(KeyValueStoreUtils.getString(entry));
+    }
+
+    @Test
+    public void testGetString_Success() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_STRING.name();
+        entry.value = VALUE_STRING;
+        entry.key = KEY;
+
+        assertEquals(VALUE_STRING, KeyValueStoreUtils.getString(entry));
+    }
+
+    @Test
+    public void testGetArray_NullEntry() {
+        assertNull(KeyValueStoreUtils.getArray(TEST_APP_NAME, null, String.class));
+    }
+
+    @Test
+    public void testGetArray_NullOrEmptyValue() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_ARRAY.name();
+
+        // null value
+        entry.value = null;
+        assertNull(KeyValueStoreUtils.getArray(TEST_APP_NAME, entry, String.class));
+
+        // empty value
+        entry.value = "";
+        assertNull(KeyValueStoreUtils.getArray(TEST_APP_NAME, entry, String.class));
+
+    }
+
+    @Test
+    public void testGetArray_Success() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_ARRAY.name();
+        entry.value = VALUE_ARRAY;
+        entry.key = KEY;
+
+        ArrayList<String> result = KeyValueStoreUtils.getArray(TEST_APP_NAME, entry, String.class);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("testItem1", result.get(0));
+        assertEquals("testItem2", result.get(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetArray_TypeMismatch() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_STRING.name();
+        entry.value = VALUE_ARRAY;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getArray(TEST_APP_NAME, entry, String.class);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testGetArray_InvalidJson() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_ARRAY.name();
+        entry.value = VALUE_MISMATCH;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getArray(TEST_APP_NAME, entry, String.class);
+    }
+
+    @Test
+    public void testGetObject_NullEntry() {
+        assertNull(KeyValueStoreUtils.getObject(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetObject_TypeMismatch() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_INTEGER.name();
+        entry.value = VALUE_OBJECT;
+        entry.key = KEY;
+
+        KeyValueStoreUtils.getObject(entry);
+    }
+
+    @Test
+    public void testGetObject_Success() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_OBJECT.name();
+        entry.value = VALUE_OBJECT;
+        entry.key = KEY;
+
+        assertEquals(VALUE_OBJECT, KeyValueStoreUtils.getObject(entry));
+    }
+
+    @Test
+    public void testGetObject_SupportsArray() {
+        KeyValueStoreEntry entry = new KeyValueStoreEntry();
+        entry.type = TYPE_ARRAY.name();
+        entry.value = VALUE_ARRAY;
+        entry.key = KEY;
+
+        assertEquals(VALUE_ARRAY, KeyValueStoreUtils.getObject(entry));
+    }
+}
+


### PR DESCRIPTION
This pull request addresses issue #522 by adding tests for the KeyStoreValueUtils class.

`testBuildEntry`
Verifies that a KeyValueStoryEntry object is instantiated correctly.

`testGetNumber_NullEntry`
Ensures that a null entry is handled correctly and returns a null value.

`testGetNumber_TypeMismatch`
Verifies that a value property of an entry referencing a wrong data type causes an IllegalArgumentException when retrieved.

`testGetNumber_Success`
Validates the successful retrieval of the value property of data type Double from an entry.

`testGetNumber_InvalidNumber`
Verifies that an entry with a value property referencing a non-numerical data type causes an IllegalArgumentException when retrieved.

`testGetInteger_NullEntry`
Verifies that a null entry does not throw an exception and returns a null value.

`testGetInteger_TypeMismatch`
Verifies that a value property of an entry referencing a numerical value of wrong data type causes an IllegalArgumentException when retrieved.

`testGetInteger_Success`
Validates the successful retrieval of the value property of data type Integer from an entry.

`testGetInteger_InvalidNumber`
Verifies that an entry with a value property referencing a non-numerical data tyoecauses an IllegalArgumentException when retrieved.

`testGetBoolean_NullEntry`
Verifies that a null entry does not throw an exception and returns a null value.

`testGetBoolean_NullValue`
Verifies that a null value is returned when an entry with a value property has a null reference.

`testGetBoolean_TypeMismatch`
Verifies that the value property of an entry referencing a wrong data type causes an IllegalArgumentException when retrieved.

`testGetBoolean_SuccessTrue`
Validates that an entry with a value property of data type Boolean is true.

`testGetBoolean_SuccessFalse`
Validates that an entry with a value property of data type Boolean is false.

`testGetBoolean_SuccessOne`
Validates that a Boolean value of true is returned from an entry with a value property referencing 1.

`testGetBoolean_SuccessZero`
Validates that a Boolean value of false is returned from an entry with a value property referencing 0.

`testGetBoolean_InvalidBoolean`
Verifies that an entry with a value property containing a non-boolean value causes an IllegalArgumentException when retrieved.

`testGetString_NullEntry`
Verifies that a null entry does not throw an exception and returns a null value.

`testGetString_NullValue`
Verifies that a null value is returned when an entry with a value property has a null reference.

`testGetString_Success`
Validates that a string is returned from an entry with a property value containing a non-null value or non-object.

`testGetArray_NullEntry`
Verifies that a null entry does not throw an exception and returns a null value.

`testGetArray_NullOrEmptyValue`
Verifies that an entry with a value property referencing an empty value or a null reference does not cause an exception and returns null.

`testGetArray_Success`
Validates that the value property of an entry referencing an array of strings is retrieved successfully.

`testGetArray_TypeMismatch`
Verifies that an entry with a value property of type referencing a non-array value causes an IllegalArgumentException.

`testGetArray_InvalidJson`
Verifies that a non-json value property of an entry cannot be mapped to an array and causes an IllegalArgumentException.

`testGetObject_NullEntry`
Verifies that a null entry does not throw an exception and returns a null value.

`testGetObject_TypeMismatch`
Verifies that a value property of an entry that neither references an object nor an array will cause an IllegalArgumentException.

`testGetObject_Success`
Validates that the value property of an entry referencing an object is retrieved successfully.

`testGetObject_SupportsArray`
Validate that the value property of an entry referencing an array can be retrieved and mapped to an object.

![image](https://github.com/user-attachments/assets/b983ffe2-bb78-4ca8-9554-6d624489a313)
